### PR TITLE
AWS Parameter Store DB 관련 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	//AWS Parameter Store
+	implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.1.0')
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,7 @@ spring:
   config:
     activate:
       on-profile: dev
+    import: aws-parameterstore:/db-config/dev/
   jpa:
     hibernate:
       ddl-auto: update
@@ -66,6 +67,7 @@ spring:
   config:
     activate:
       on-profile: prod
+    import: aws-parameterstore:/db-config/prd/
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,38 @@
 spring:
   profiles:
-    default: dev
+    default: local
   datasource:
     url: ${DATABASE_URL}
     username: ${DATABASE_ID}
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        highlight_sql: true
+        show_sql: true
+        format_sql: true
+        default_batch_fetch_size: 100
+    database: mysql
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+
+logging:
+  level:
+    root: info
+    org.hibernate.sql: info
+    org.hibernate.type.descriptor.sql: trace
+    com.project.foradhd: debug
 
 ---
 spring:


### PR DESCRIPTION
## 💻 구현 내용 

- 실행 프로필 `local`(로컬), `dev`(개발), `prd`(운영)으로 분리
- `dev`, `prd` 프로필의 경우 로그 레벨과 ddl 설정을 제외하고 거의 동일 (현재 서버, db 1개 밖에 없기 때문)
- `dev`, `prd` 프로필로 실행한 경우에는 parameter store로부터 db 설정 정보를 받아오지만, `local` 프로필로 실행한 경우에는 현재 실행 환경의 환경 변수 값 받아옴

## 🗣️ For 리뷰어

### application.yml 설명

```gradle
# 아래는 모든 프로필에 공통된 설정
spring:
  profiles:
    default: local
  datasource:
    url: ${DATABASE_URL}
    username: ${DATABASE_ID}
    password: ${DATABASE_PASSWORD}
    driver-class-name: com.mysql.cj.jdbc.Driver

# --- 부터 다음 --- 가 나오기 전까지 local 프로필에 대한 설정
---
spring:
  config:
    activate:
      on-profile: local
  jpa:
    hibernate:
      ddl-auto: update
    properties:
      hibernate:
        highlight_sql: true
        show_sql: true
        format_sql: true
        default_batch_fetch_size: 100
    database: mysql
  data:
    web:
      pageable:
        one-indexed-parameters: true

logging:
  level:
    root: info
    org.hibernate.sql: info
    org.hibernate.type.descriptor.sql: trace
    com.project.foradhd: debug

---
spring:
  config:
    activate:
      on-profile: dev
    import: aws-parameterstore:/db-config/dev/ # dev, prd 프로필에만 해당 설정 추가
  jpa:
    hibernate:
      ddl-auto: update
    properties:
      hibernate:
        highlight_sql: true
        show_sql: true
        format_sql: true
        default_batch_fetch_size: 100
    database: mysql
  data:
    web:
      pageable:
        one-indexed-parameters: true

logging:
  level:
    root: info
    org.hibernate.sql: info
    org.hibernate.type.descriptor.sql: trace
    com.project.foradhd: debug
```
- yml 설정의 `/db-config/dev/` 키 값에 대응하는 변수 `DATABASE_URL`, `DATABASE_ID`, `DATABASE_PASSWORD`를 읽어와 현재 스프링 어플리케이션의 environment properties에 등록, 즉 맨 위 설정의 `${DATABASE_URL}`에 읽어온 값이 주입되는 것
- 현재 파라미터 스토어에 등록된 파라미터

  <img src="https://github.com/team-forAdhd/forAdhd-server/assets/65665065/cb1df254-bd15-4a27-896e-bdabc52bcb28" width="80%"/>

### 자세한 내용은 아래 참고
[Spring Cloud AWS 공식 문서](https://docs.awspring.io/spring-cloud-aws/docs/3.1.0/reference/html/index.html#spring-cloud-aws-parameter-store)
[spring boot 3.2에서 aws parameter store 적용하기](https://velog.io/@as9587/spring-boot-3.2%EC%97%90%EC%84%9C-aws-parameter-store-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)

### IntelliJ에서 `${DATABASE_URL}`, `${DATABASE_ID}`, `${DATABASE_PASSWORD}` 환경 변수 설정 방법
  
- Edit Configurations > Environment varaiables 설정 추가 > 아래와 같이 등록
  ![image](https://github.com/team-forAdhd/forAdhd-server/assets/65665065/49d21d7f-e402-4f16-9582-f0250c2897aa)

close #1 