### PR TITLE
소셜 로그인 후 추가 회원가입 및 유저 정보 CRUD 구현

### DIFF
--- a/src/main/java/com/project/foradhd/domain/auth/business/dto/out/AuthTokenData.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/dto/out/AuthTokenData.java
@@ -1,0 +1,13 @@
+package com.project.foradhd.domain.auth.business.dto.out;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthTokenData {
+
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/AuthService.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/AuthService.java
@@ -1,0 +1,48 @@
+package com.project.foradhd.domain.auth.business.service;
+
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+import com.project.foradhd.domain.auth.business.dto.out.AuthTokenData;
+import com.project.foradhd.domain.user.business.service.UserService;
+import com.project.foradhd.domain.user.persistence.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class AuthService {
+
+    private final JwtService jwtService;
+    private final UserService userService;
+
+    public AuthTokenData reissue(String userId, String accessToken, String refreshToken) {
+        validateAuthToken(userId, accessToken, refreshToken);
+
+        User user = userService.getUser(userId);
+        String reissuedAccessToken = jwtService.generateAccessToken(userId, user.getEmail(),
+            createAuthorityList(user.getAuthority()));
+        String reissuedRefreshToken = jwtService.generateRefreshToken(userId);
+        //TODO: RT 저장 로직 구현
+        return new AuthTokenData(reissuedAccessToken, reissuedRefreshToken);
+    }
+
+    private void validateAuthToken(String userId, String accessToken, String refreshToken) {
+        if (!isValidAccessToken(userId, accessToken) ||
+            !isValidRefreshToken(userId, refreshToken)) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    private boolean isValidAccessToken(String userId, String accessToken) {
+        String parsedUserId = jwtService.getSubject(accessToken);
+        return jwtService.isValidTokenForm(accessToken) && userId.equals(parsedUserId);
+    }
+
+    private boolean isValidRefreshToken(String userId, String refreshToken) {
+        String parsedUserId = jwtService.getSubject(refreshToken);
+        //TODO: RT 저장 여부 확인
+        return jwtService.isValidTokenExpiry(refreshToken) && userId.equals(parsedUserId);
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/auth/business/userdetails/impl/KakaoOAuth2Attributes.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/userdetails/impl/KakaoOAuth2Attributes.java
@@ -6,7 +6,9 @@ import com.project.foradhd.domain.user.persistence.enums.Provider;
 import java.time.LocalDate;
 import java.util.Map;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class KakaoOAuth2Attributes extends OAuth2Attributes {
@@ -55,5 +57,23 @@ public class KakaoOAuth2Attributes extends OAuth2Attributes {
         Boolean isEmailValid = (Boolean) userInfo.get(EMAIL_VALID_KEY);
         Boolean isEmailVerified = (Boolean) userInfo.get(EMAIL_VERIFIED_KEY);
         return isEmailValid && isEmailVerified;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    enum KakaoGender {
+
+        MALE(Gender.MALE), FEMALE(Gender.FEMALE);
+
+        private final Gender gender;
+
+        public static Gender from(String value) {
+            try {
+                KakaoGender kakaoGender = KakaoGender.valueOf(value.toUpperCase());
+                return kakaoGender.getGender();
+            } catch (IllegalArgumentException e) {
+                return Gender.UNKNOWN;
+            }
+        }
     }
 }

--- a/src/main/java/com/project/foradhd/domain/auth/business/userdetails/impl/NaverOAuth2Attributes.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/userdetails/impl/NaverOAuth2Attributes.java
@@ -1,5 +1,9 @@
 package com.project.foradhd.domain.auth.business.userdetails.impl;
 
+import static com.project.foradhd.domain.user.persistence.enums.Gender.FEMALE;
+import static com.project.foradhd.domain.user.persistence.enums.Gender.MALE;
+import static com.project.foradhd.domain.user.persistence.enums.Gender.UNKNOWN;
+
 import com.project.foradhd.domain.auth.business.userdetails.OAuth2Attributes;
 import com.project.foradhd.domain.user.persistence.enums.Gender;
 import com.project.foradhd.domain.user.persistence.enums.Provider;
@@ -9,7 +13,9 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Map;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NaverOAuth2Attributes extends OAuth2Attributes {
@@ -51,7 +57,7 @@ public class NaverOAuth2Attributes extends OAuth2Attributes {
 
     private static Gender parseGender(Map<String, Object> userInfo) {
         String gender = (String) userInfo.get(GENDER_KEY);
-        return Gender.from(gender);
+        return NaverGender.from(gender);
     }
 
     private static String parseAgeRange(Map<String, Object> userInfo) {
@@ -63,5 +69,23 @@ public class NaverOAuth2Attributes extends OAuth2Attributes {
         String birthDay = (String) userInfo.get(BIRTH_DAY_KEY);
         TemporalAccessor birthDayTemporalAccessor = BIRTH_DAY_FORMATTER.parse(birthDay);
         return MonthDay.from(birthDayTemporalAccessor).atYear(birthYear);
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    enum NaverGender {
+
+        M(MALE), F(FEMALE), U(UNKNOWN);
+
+        private final Gender gender;
+
+        public static Gender from(String value) {
+            try {
+                NaverGender naverGender = NaverGender.valueOf(value.toUpperCase());
+                return naverGender.getGender();
+            } catch (IllegalArgumentException e) {
+                return Gender.UNKNOWN;
+            }
+        }
     }
 }

--- a/src/main/java/com/project/foradhd/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/project/foradhd/domain/auth/web/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.project.foradhd.domain.auth.web.controller;
+
+import com.project.foradhd.domain.auth.business.dto.out.AuthTokenData;
+import com.project.foradhd.domain.auth.business.service.AuthService;
+import com.project.foradhd.domain.auth.web.dto.request.TokenReissueRequest;
+import com.project.foradhd.domain.auth.web.dto.response.TokenReissueResponse;
+import com.project.foradhd.domain.auth.web.mapper.AuthMapper;
+import com.project.foradhd.global.AuthUserId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+    private final AuthMapper authMapper;
+
+    @PutMapping("/reissue")
+    public ResponseEntity<TokenReissueResponse> reissue(@AuthUserId String userId,
+        @RequestBody @Valid TokenReissueRequest request) {
+        AuthTokenData authTokenData = authService.reissue(userId, request.getAccessToken(), request.getRefreshToken());
+        TokenReissueResponse response = authMapper.toTokenReissueResponse(authTokenData);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthUserId String userId) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/auth/web/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/project/foradhd/domain/auth/web/dto/request/TokenReissueRequest.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.auth.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class TokenReissueRequest {
+
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/project/foradhd/domain/auth/web/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/project/foradhd/domain/auth/web/dto/response/TokenReissueResponse.java
@@ -1,0 +1,13 @@
+package com.project.foradhd.domain.auth.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenReissueResponse {
+
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/project/foradhd/domain/auth/web/mapper/AuthMapper.java
+++ b/src/main/java/com/project/foradhd/domain/auth/web/mapper/AuthMapper.java
@@ -1,0 +1,12 @@
+package com.project.foradhd.domain.auth.web.mapper;
+
+import com.project.foradhd.domain.auth.business.dto.out.AuthTokenData;
+import com.project.foradhd.domain.auth.web.dto.response.TokenReissueResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants.ComponentModel;
+
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface AuthMapper {
+
+    TokenReissueResponse toTokenReissueResponse(AuthTokenData authTokenData);
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/dto/in/EmailUpdateData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/in/EmailUpdateData.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.user.business.dto.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailUpdateData {
+
+    private String email;
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/dto/in/PasswordUpdateData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/in/PasswordUpdateData.java
@@ -1,0 +1,15 @@
+package com.project.foradhd.domain.user.business.dto.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PasswordUpdateData {
+
+    private String prevPassword;
+
+    private String password;
+
+    private String passwordConfirm;
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/dto/in/ProfileUpdateData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/in/ProfileUpdateData.java
@@ -1,0 +1,15 @@
+package com.project.foradhd.domain.user.business.dto.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileUpdateData {
+
+    private String nickname;
+
+    private String profileImage;
+
+    private Boolean isAdhd;
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/dto/in/PushNotificationAgreeUpdateData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/in/PushNotificationAgreeUpdateData.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.user.business.dto.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PushNotificationAgreeUpdateData {
+
+    private Boolean pushNotificationAgree;
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/dto/in/SnsSignUpData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/in/SnsSignUpData.java
@@ -1,0 +1,15 @@
+package com.project.foradhd.domain.user.business.dto.in;
+
+import com.project.foradhd.domain.user.persistence.entity.User;
+import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SnsSignUpData {
+
+    private User user;
+    private List<UserTermsApproval> userTermsApprovals;
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/dto/in/TermsApprovalsUpdateData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/in/TermsApprovalsUpdateData.java
@@ -1,0 +1,13 @@
+package com.project.foradhd.domain.user.business.dto.in;
+
+import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TermsApprovalsUpdateData {
+
+    private List<UserTermsApproval> userTermsApprovals;
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/dto/out/UserProfileDetailsData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/out/UserProfileDetailsData.java
@@ -1,0 +1,15 @@
+package com.project.foradhd.domain.user.business.dto.out;
+
+import com.project.foradhd.domain.user.persistence.entity.User;
+import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileDetailsData {
+
+    private User user;
+    private List<UserTermsApproval> userTermsApprovals;
+}

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
@@ -31,6 +31,10 @@ public class UserService {
     private final UserTermsApprovalRepository userTermsApprovalRepository;
     private final PasswordEncoder passwordEncoder;
 
+    public boolean checkNickname(String nickname) {
+        return userRepository.findByNickname(nickname).isEmpty();
+    }
+
     @Transactional
     public void signUp(SignUpData signUpData, String password) {
         User user = signUpData.getUser();

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
@@ -7,6 +7,7 @@ import com.project.foradhd.domain.user.business.dto.in.PushNotificationAgreeUpda
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
+import com.project.foradhd.domain.user.business.dto.out.UserProfileDetailsData;
 import com.project.foradhd.domain.user.persistence.entity.Terms;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
@@ -33,6 +34,15 @@ public class UserService {
 
     public boolean checkNickname(String nickname) {
         return userRepository.findByNickname(nickname).isEmpty();
+    }
+
+    public UserProfileDetailsData getUserProfileDetails(String userId) {
+        User user = getUser(userId);
+        List<UserTermsApproval> userTermsApprovals = userTermsApprovalRepository.findByUserId(userId);
+        return UserProfileDetailsData.builder()
+            .user(user)
+            .userTermsApprovals(userTermsApprovals)
+            .build();
     }
 
     @Transactional

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
@@ -1,5 +1,6 @@
 package com.project.foradhd.domain.user.business.service;
 
+import com.project.foradhd.domain.user.business.dto.in.ProfileUpdateData;
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.persistence.entity.Terms;
@@ -49,6 +50,14 @@ public class UserService {
         User snsUser = getUser(userId);
         snsUser.snsSignUp(user);
         userTermsApprovalRepository.saveAll(userTermsApprovals);
+    }
+
+    @Transactional
+    public void updateProfile(String userId, ProfileUpdateData profileUpdateData) {
+        User user = getUser(userId);
+        validateDuplicatedNickname(profileUpdateData.getNickname());
+        user.updateProfile(profileUpdateData.getNickname(), profileUpdateData.getProfileImage(),
+            profileUpdateData.getIsAdhd());
     }
 
     public User getUser(String userId) {

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
@@ -100,8 +100,16 @@ public class User extends BaseTimeEntity {
         this.isAdhd = isAdhd;
     }
 
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
     public void updateEncodedPassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    public void updatePushNotificationAgree(Boolean pushNotificationAgree) {
+        this.pushNotificationAgree = pushNotificationAgree;
     }
 
     public User loginBySns(User snsUser) {

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
@@ -106,4 +106,12 @@ public class User extends BaseTimeEntity {
         this.birth = snsUser.birth;
         return this;
     }
+
+    public void snsSignUp(User user) {
+        this.role = Role.USER;
+        this.nickname = user.getNickname();
+        this.profileImage = user.getProfileImage();
+        this.isAdhd = user.getIsAdhd();
+        this.pushNotificationAgree = user.getPushNotificationAgree();
+    }
 }

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
@@ -94,6 +94,12 @@ public class User extends BaseTimeEntity {
         return this.role.getName();
     }
 
+    public void updateProfile(String nickname, String profileImage, Boolean isAdhd) {
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.isAdhd = isAdhd;
+    }
+
     public void updateEncodedPassword(String encodedPassword) {
         this.password = encodedPassword;
     }

--- a/src/main/java/com/project/foradhd/domain/user/persistence/enums/Gender.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/enums/Gender.java
@@ -2,13 +2,5 @@ package com.project.foradhd.domain.user.persistence.enums;
 
 public enum Gender {
 
-    MALE, FEMALE, UNKNOWN;
-
-    public static Gender from(String value) {
-        try {
-            return Gender.valueOf(value.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            return UNKNOWN;
-        }
-    }
+    MALE, FEMALE, UNKNOWN
 }

--- a/src/main/java/com/project/foradhd/domain/user/persistence/repository/UserTermsApprovalRepository.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/repository/UserTermsApprovalRepository.java
@@ -2,8 +2,19 @@ package com.project.foradhd.domain.user.persistence.repository;
 
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval.UserTermsApprovalId;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserTermsApprovalRepository extends JpaRepository<UserTermsApproval, UserTermsApprovalId> {
 
+    //TODO: Querydsl로 빼자
+    @Query("""
+        select uta from UserTermsApproval uta 
+        inner join Terms t on t.id = uta.id.terms.id
+        where uta.id.user.id = :userId
+        order by t.seq
+    """)
+    List<UserTermsApproval> findByUserId(@Param("userId") String userId);
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -9,12 +9,14 @@ import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.web.dto.request.EmailUpdateRequest;
+import com.project.foradhd.domain.user.web.dto.request.NicknameCheckRequest;
 import com.project.foradhd.domain.user.web.dto.request.PasswordUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.ProfileUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.PushNotificationAgreeUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.TermsApprovalsUpdateRequest;
+import com.project.foradhd.domain.user.web.dto.response.NicknameCheckResponse;
 import com.project.foradhd.domain.user.web.mapper.UserMapper;
 import com.project.foradhd.global.AuthUserId;
 import jakarta.validation.Valid;
@@ -35,6 +37,12 @@ public class UserController {
 
     private final UserService userService;
     private final UserMapper userMapper;
+
+    @GetMapping("/nickname-check")
+    public ResponseEntity<NicknameCheckResponse> checkNickname(@RequestBody @Valid NicknameCheckRequest request) {
+        boolean isValidNickname = userService.checkNickname(request.getNickname());
+        return ResponseEntity.ok(new NicknameCheckResponse(isValidNickname));
+    }
 
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.project.foradhd.domain.user.web.controller;
 
+import com.project.foradhd.domain.user.business.dto.in.ProfileUpdateData;
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.service.UserService;
+import com.project.foradhd.domain.user.web.dto.request.ProfileUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
 import com.project.foradhd.domain.user.web.mapper.UserMapper;
@@ -11,8 +13,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,5 +40,13 @@ public class UserController {
         SnsSignUpData snsSignUpData = userMapper.toSnsSignUpData(userId, request);
         userService.snsSignUp(userId, snsSignUpData);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<Void> updateProfile(@AuthUserId String userId,
+        @RequestBody @Valid ProfileUpdateRequest request) {
+        ProfileUpdateData profileUpdateData = userMapper.toProfileUpdateData(request);
+        userService.updateProfile(userId, profileUpdateData);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -7,6 +7,7 @@ import com.project.foradhd.domain.user.business.dto.in.PushNotificationAgreeUpda
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
+import com.project.foradhd.domain.user.business.dto.out.UserProfileDetailsData;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.web.dto.request.EmailUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.NicknameCheckRequest;
@@ -17,6 +18,7 @@ import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.TermsApprovalsUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.response.NicknameCheckResponse;
+import com.project.foradhd.domain.user.web.dto.response.UserProfileDetailsResponse;
 import com.project.foradhd.domain.user.web.mapper.UserMapper;
 import com.project.foradhd.global.AuthUserId;
 import jakarta.validation.Valid;
@@ -42,6 +44,13 @@ public class UserController {
     public ResponseEntity<NicknameCheckResponse> checkNickname(@RequestBody @Valid NicknameCheckRequest request) {
         boolean isValidNickname = userService.checkNickname(request.getNickname());
         return ResponseEntity.ok(new NicknameCheckResponse(isValidNickname));
+    }
+
+    @GetMapping
+    public ResponseEntity<UserProfileDetailsResponse> getUserProfileDetails(@AuthUserId String userId) {
+        UserProfileDetailsData userProfileDetailsData = userService.getUserProfileDetails(userId);
+        UserProfileDetailsResponse response = userMapper.toUserProfileDetailsResponse(userProfileDetailsData);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/sign-up")

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -1,18 +1,27 @@
 package com.project.foradhd.domain.user.web.controller;
 
+import com.project.foradhd.domain.user.business.dto.in.EmailUpdateData;
+import com.project.foradhd.domain.user.business.dto.in.PasswordUpdateData;
 import com.project.foradhd.domain.user.business.dto.in.ProfileUpdateData;
+import com.project.foradhd.domain.user.business.dto.in.PushNotificationAgreeUpdateData;
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
+import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
 import com.project.foradhd.domain.user.business.service.UserService;
+import com.project.foradhd.domain.user.web.dto.request.EmailUpdateRequest;
+import com.project.foradhd.domain.user.web.dto.request.PasswordUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.ProfileUpdateRequest;
+import com.project.foradhd.domain.user.web.dto.request.PushNotificationAgreeUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
+import com.project.foradhd.domain.user.web.dto.request.TermsApprovalsUpdateRequest;
 import com.project.foradhd.domain.user.web.mapper.UserMapper;
 import com.project.foradhd.global.AuthUserId;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,6 +56,38 @@ public class UserController {
         @RequestBody @Valid ProfileUpdateRequest request) {
         ProfileUpdateData profileUpdateData = userMapper.toProfileUpdateData(request);
         userService.updateProfile(userId, profileUpdateData);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> updatePassword(@AuthUserId String userId,
+        @RequestBody @Valid PasswordUpdateRequest request) {
+        PasswordUpdateData passwordUpdateData = userMapper.toPasswordUpdateData(request);
+        userService.updatePassword(userId, passwordUpdateData);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/email")
+    public ResponseEntity<Void> updateEmail(@AuthUserId String userId,
+        @RequestBody @Valid EmailUpdateRequest request) {
+        EmailUpdateData emailUpdateData = userMapper.toEmailUpdateData(request);
+        userService.updateEmail(userId, emailUpdateData);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/push-notification-agree")
+    public ResponseEntity<Void> updatePushNotificationAgree(@AuthUserId String userId,
+        @RequestBody @Valid PushNotificationAgreeUpdateRequest request) {
+        PushNotificationAgreeUpdateData pushNotificationAgreeUpdateData = userMapper.toPushNotificationAgreeUpdateData(request);
+        userService.updatePushNotificationAgree(userId, pushNotificationAgreeUpdateData);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/terms-approvals")
+    public ResponseEntity<Void> updateTermsApprovals(@AuthUserId String userId,
+        @RequestBody @Valid TermsApprovalsUpdateRequest request) {
+        TermsApprovalsUpdateData termsApprovalsUpdateData = userMapper.toTermsApprovalsUpdateData(userId, request);
+        userService.updateTermsApprovals(termsApprovalsUpdateData);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -1,14 +1,20 @@
 package com.project.foradhd.domain.user.web.controller;
 
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
+import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
+import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
 import com.project.foradhd.domain.user.web.mapper.UserMapper;
+import com.project.foradhd.global.AuthUserId;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,8 +29,16 @@ public class UserController {
 
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
-        SignUpData signUpDto = userMapper.toSignUpData(request);
-        userService.signUp(signUpDto, request.getPassword());
+        SignUpData signUpData = userMapper.toSignUpData(request);
+        userService.signUp(signUpData, request.getPassword());
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PostMapping("/sns-sign-up")
+    public ResponseEntity<Void> snsSignUp(@AuthUserId String userId,
+        @RequestBody @Valid SnsSignUpRequest request) {
+        SnsSignUpData snsSignUpData = userMapper.toSnsSignUpData(userId, request);
+        userService.snsSignUp(userId, snsSignUpData);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/EmailUpdateRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/EmailUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class EmailUpdateRequest {
+
+    private String email;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/NicknameCheckRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/NicknameCheckRequest.java
@@ -1,0 +1,9 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class NicknameCheckRequest {
+
+    private String nickname;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/PasswordUpdateRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/PasswordUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PasswordUpdateRequest {
+
+    private String prevPassword;
+
+    private String password;
+
+    private String passwordConfirm;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileUpdateRequest {
+
+    private String nickname;
+
+    private String profileImage;
+
+    private Boolean isAdhd;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/PushNotificationAgreeUpdateRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/PushNotificationAgreeUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PushNotificationAgreeUpdateRequest {
+
+    private Boolean pushNotificationAgree;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/SnsSignUpRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/SnsSignUpRequest.java
@@ -1,0 +1,26 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SnsSignUpRequest {
+
+    private String nickname;
+
+    private String profileImage;
+
+    private Boolean isAdhd;
+
+    private Boolean pushNotificationAgree;
+
+    private List<SignUpRequest.TermsApprovalRequest> termsApprovals;
+
+    @Getter
+    public static class TermsApprovalRequest {
+
+        private Long termsId;
+
+        private Boolean approved;
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/TermsApprovalsUpdateRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/TermsApprovalsUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class TermsApprovalsUpdateRequest {
+
+    private List<SignUpRequest.TermsApprovalRequest> termsApprovals;
+
+    @Getter
+    public static class TermsApprovalRequest {
+
+        private Long termsId;
+
+        private Boolean approved;
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/response/NicknameCheckResponse.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/response/NicknameCheckResponse.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.user.web.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NicknameCheckResponse {
+
+    private Boolean isValidNickname;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/response/UserProfileDetailsResponse.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/response/UserProfileDetailsResponse.java
@@ -1,0 +1,42 @@
+package com.project.foradhd.domain.user.web.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.project.foradhd.domain.user.persistence.enums.Gender;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileDetailsResponse {
+
+    private String name;
+
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyyMMdd", timezone = "Asia/Seoul")
+    private LocalDate birth;
+
+    private Gender gender;
+
+    private String email;
+
+    private String nickname;
+
+    private String profileImage;
+
+    private Boolean isAdhd;
+
+    private Boolean pushNotificationAgree;
+
+    private List<TermsApprovalResponse> termsApprovals;
+
+    @Getter
+    @Builder
+    public static class TermsApprovalResponse {
+
+        private Long termsId;
+
+        private Boolean approved;
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.project.foradhd.domain.user.web.mapper;
 
+import com.project.foradhd.domain.user.business.dto.in.ProfileUpdateData;
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.persistence.entity.Terms;
@@ -8,6 +9,7 @@ import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval.UserTermsApprovalId;
 import com.project.foradhd.domain.user.persistence.enums.Provider;
 import com.project.foradhd.domain.user.persistence.enums.Role;
+import com.project.foradhd.domain.user.web.dto.request.ProfileUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
 import java.util.List;
@@ -72,4 +74,6 @@ public interface UserMapper {
                 .build())
             .toList();
     }
+
+    ProfileUpdateData toProfileUpdateData(ProfileUpdateRequest request);
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
@@ -1,17 +1,25 @@
 package com.project.foradhd.domain.user.web.mapper;
 
+import com.project.foradhd.domain.user.business.dto.in.EmailUpdateData;
+import com.project.foradhd.domain.user.business.dto.in.PasswordUpdateData;
 import com.project.foradhd.domain.user.business.dto.in.ProfileUpdateData;
+import com.project.foradhd.domain.user.business.dto.in.PushNotificationAgreeUpdateData;
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
+import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
 import com.project.foradhd.domain.user.persistence.entity.Terms;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval.UserTermsApprovalId;
 import com.project.foradhd.domain.user.persistence.enums.Provider;
 import com.project.foradhd.domain.user.persistence.enums.Role;
+import com.project.foradhd.domain.user.web.dto.request.EmailUpdateRequest;
+import com.project.foradhd.domain.user.web.dto.request.PasswordUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.ProfileUpdateRequest;
+import com.project.foradhd.domain.user.web.dto.request.PushNotificationAgreeUpdateRequest;
 import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
+import com.project.foradhd.domain.user.web.dto.request.TermsApprovalsUpdateRequest;
 import java.util.List;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -37,23 +45,10 @@ public interface UserMapper {
             .pushNotificationAgree(request.getPushNotificationAgree())
             .build();
         List<UserTermsApproval> userTermsApprovals = request.getTermsApprovals().stream()
-            .map(termsApproval -> UserTermsApproval.builder()
-                .id(mapToUserTermsApprovalId(user, termsApproval.getTermsId()))
-                .approved(termsApproval.getApproved())
-                .build())
+            .map(termsApproval ->
+                mapToUserTermsApproval(user, termsApproval.getTermsId(), termsApproval.getApproved()))
             .toList();
         return new SignUpData(user, userTermsApprovals);
-    }
-
-    default UserTermsApprovalId mapToUserTermsApprovalId(User user, Long termsId) {
-        Terms terms = Terms.builder().id(termsId).build();
-        return new UserTermsApprovalId(user, terms);
-    }
-
-    default UserTermsApprovalId mapToUserTermsApprovalId(String userId, Long termsId) {
-        User user = User.builder().id(userId).build();
-        Terms terms = Terms.builder().id(termsId).build();
-        return new UserTermsApprovalId(user, terms);
     }
 
     @Mappings({
@@ -68,12 +63,50 @@ public interface UserMapper {
     @Named("mapToUserTermsApprovals")
     default List<UserTermsApproval> mapToUserTermsApprovals(@Context String userId, SnsSignUpRequest request) {
         return request.getTermsApprovals().stream()
-            .map(termsApproval -> UserTermsApproval.builder()
-                .id(mapToUserTermsApprovalId(userId, termsApproval.getTermsId()))
-                .approved(termsApproval.getApproved())
-                .build())
+            .map(termsApproval ->
+                mapToUserTermsApproval(userId, termsApproval.getTermsId(), termsApproval.getApproved()))
             .toList();
     }
 
+    default UserTermsApprovalId mapToUserTermsApprovalId(User user, Long termsId) {
+        Terms terms = Terms.builder().id(termsId).build();
+        return new UserTermsApprovalId(user, terms);
+    }
+
+    default UserTermsApprovalId mapToUserTermsApprovalId(String userId, Long termsId) {
+        User user = User.builder().id(userId).build();
+        Terms terms = Terms.builder().id(termsId).build();
+        return new UserTermsApprovalId(user, terms);
+    }
+
+    default UserTermsApproval mapToUserTermsApproval(User user, Long termsId, Boolean approved) {
+        return UserTermsApproval.builder()
+            .id(mapToUserTermsApprovalId(user, termsId))
+            .approved(approved)
+            .build();
+    }
+
+    default UserTermsApproval mapToUserTermsApproval(String userId, Long termsId, Boolean approved) {
+        return UserTermsApproval.builder()
+            .id(mapToUserTermsApprovalId(userId, termsId))
+            .approved(approved)
+            .build();
+    }
+
     ProfileUpdateData toProfileUpdateData(ProfileUpdateRequest request);
+
+    PasswordUpdateData toPasswordUpdateData(PasswordUpdateRequest request);
+
+    EmailUpdateData toEmailUpdateData(EmailUpdateRequest request);
+
+    PushNotificationAgreeUpdateData toPushNotificationAgreeUpdateData(
+        PushNotificationAgreeUpdateRequest request);
+
+    default TermsApprovalsUpdateData toTermsApprovalsUpdateData(String userId, TermsApprovalsUpdateRequest request) {
+        List<UserTermsApproval> userTermsApprovals = request.getTermsApprovals().stream()
+            .map(termsApproval ->
+                mapToUserTermsApproval(userId, termsApproval.getTermsId(), termsApproval.getApproved()))
+            .toList();
+        return new TermsApprovalsUpdateData(userTermsApprovals);
+    }
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
@@ -7,6 +7,7 @@ import com.project.foradhd.domain.user.business.dto.in.PushNotificationAgreeUpda
 import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
+import com.project.foradhd.domain.user.business.dto.out.UserProfileDetailsData;
 import com.project.foradhd.domain.user.persistence.entity.Terms;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
@@ -20,8 +21,10 @@ import com.project.foradhd.domain.user.web.dto.request.PushNotificationAgreeUpda
 import com.project.foradhd.domain.user.web.dto.request.SignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.SnsSignUpRequest;
 import com.project.foradhd.domain.user.web.dto.request.TermsApprovalsUpdateRequest;
+import com.project.foradhd.domain.user.web.dto.response.UserProfileDetailsResponse;
 import java.util.List;
 import org.mapstruct.Context;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
@@ -30,6 +33,27 @@ import org.mapstruct.Named;
 
 @Mapper(componentModel = ComponentModel.SPRING)
 public interface UserMapper {
+
+    @Mappings({
+        @Mapping(target = "name", source = "user.name"),
+        @Mapping(target = "birth", source = "user.birth"),
+        @Mapping(target = "gender", source = "user.gender"),
+        @Mapping(target = "email", source = "user.email"),
+        @Mapping(target = "nickname", source = "user.nickname"),
+        @Mapping(target = "profileImage", source = "user.profileImage"),
+        @Mapping(target = "isAdhd", source = "user.isAdhd"),
+        @Mapping(target = "pushNotificationAgree", source = "user.pushNotificationAgree"),
+        @Mapping(target = "termsApprovals", source = "userTermsApprovals", qualifiedByName = "mapToTermsApprovals")
+    })
+    UserProfileDetailsResponse toUserProfileDetailsResponse(UserProfileDetailsData userProfileDetailsData);
+
+    @Named("mapToTermsApprovals")
+    @IterableMapping(qualifiedByName = "mapToTermsApproval")
+    List<UserProfileDetailsResponse.TermsApprovalResponse> mapToTermsApprovals(List<UserTermsApproval> userTermsApprovals);
+
+    @Named("mapToTermsApproval")
+    @Mapping(target = "termsId", source = "id.terms.id")
+    UserProfileDetailsResponse.TermsApprovalResponse mapToTermsApproval(UserTermsApproval userTermsApprovals);
 
     default SignUpData toSignUpData(SignUpRequest request) {
         User user = User.builder()

--- a/src/main/java/com/project/foradhd/global/AuthUserId.java
+++ b/src/main/java/com/project/foradhd/global/AuthUserId.java
@@ -1,0 +1,14 @@
+package com.project.foradhd.global;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface AuthUserId {
+
+}

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -42,8 +42,10 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 @Configuration
 public class SecurityConfig {
 
+    private static final String NICKNAME_CHECK_API_PATH = "/api/v1/user/nickname-check";
     private static final String SIGN_UP_API_PATH = "/api/v1/user/sign-up";
     private static final String LOGIN_API_PATH = "/api/v1/auth/login";
+    private static final String AUTH_TOKEN_REISSUE_API_PATH = "/api/v1/auth/reissue";
     private static final String HEALTH_CHECK_API_PATH = "/api/v1/health-check";
 
     private static final String EMAIL_AUTH_API_PATH = "/api/v1/user/email-auth";
@@ -69,7 +71,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(registry -> registry
-                .requestMatchers(SIGN_UP_API_PATH, LOGIN_API_PATH, HEALTH_CHECK_API_PATH).permitAll()
+                .requestMatchers(NICKNAME_CHECK_API_PATH, SIGN_UP_API_PATH, LOGIN_API_PATH,
+                    AUTH_TOKEN_REISSUE_API_PATH, HEALTH_CHECK_API_PATH).permitAll()
                 .requestMatchers("/error", "/favicon.ico").permitAll()
                 .requestMatchers(EMAIL_AUTH_API_PATH, SNS_SIGN_UP_API_PATH, LOGOUT_API_PATH).hasRole(Role.GUEST.name())
                 .anyRequest().hasRole(Role.USER.name()))

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
     private static final String HEALTH_CHECK_API_PATH = "/api/v1/health-check";
 
     private static final String EMAIL_AUTH_API_PATH = "/api/v1/user/email-auth";
+    private static final String SNS_SIGN_UP_API_PATH = "/api/v1/user/sns-sign-up";
     private static final String LOGOUT_API_PATH = "/api/v1/auth/logout";
 
     private static final RequestMatcher loginMatcher = new AntPathRequestMatcher(LOGIN_API_PATH, POST.name());
@@ -70,7 +71,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(registry -> registry
                 .requestMatchers(SIGN_UP_API_PATH, LOGIN_API_PATH, HEALTH_CHECK_API_PATH).permitAll()
                 .requestMatchers("/error", "/favicon.ico").permitAll()
-                .requestMatchers(EMAIL_AUTH_API_PATH, LOGOUT_API_PATH).hasRole(Role.GUEST.name())
+                .requestMatchers(EMAIL_AUTH_API_PATH, SNS_SIGN_UP_API_PATH, LOGOUT_API_PATH).hasRole(Role.GUEST.name())
                 .anyRequest().hasRole(Role.USER.name()))
             .sessionManagement(config -> config
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -32,6 +32,15 @@ spring:
               - birthyear
               - age
               - gender
+          facebook:
+            client-id: ENC(N+8OKapW80anlr3JUxC5Hnsj79AsiOYJXU1LKYWHOkc=)
+            client-secret: ENC(ICCDO1J0O8sx31C2YYmuXzfV5Zhw2M+GVwjVNI9YGKi/mcu3AbHLdwN0ORrXoigN)
+            scope:
+              - email
+              - public_profile
+              - user_birthday
+              - user_age_range
+              - user_gender
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
## 💻 구현 내용 

- 닉네임 중복 여부 확인 api
- 유저 프로필 상세 조회 api
- 소셜 로그인 시 추가 회원가입 api
- 유저 프로필 수정 api
- 비밀번호 재설정 api
- 이메일 수정 api
- 푸시 알림 동의 여부 변경 api
- 이용 약관 동의 여부 변경 api
- 인증 토큰 재발급 api

## 🗣️ For 리뷰어

이번 PR에서는 유저 정보 관련 CRUD만 구현하여 이해하시기에 복잡한 로직은 없을 겁니다. 전반적인 코드 컨벤션, 불필요한 로직은 없는지 확인 부탁드려요. 

추가로 오늘 회의 시간에 말씀드릴 논의 사항으로 유저, 인증 쪽 테이블 구조가 많이 바뀌게 될 수 있을 것 같아 아직 테스트 코드는 작성하지 않았습니다. (약간의 변명...🥲) 논의 픽스된 후 변경 사항 적용하면서 다음주에 테스트 코드 작성하겠습니다. 

\+ 페이스북 로그인 구현하기 위해 앱 등록하는 과정에서 페이스북 계정 생성이 안되어서 일단 유저쪽 CRUD 먼저 구현하였습니다. 현재 계정 생성 후 앱 등록은 되었는데 페이스북 쪽에서 우리 앱에 로그인 권한?을 아직 안주어서 정상적으로 로그인이 안됩니다. 페이스북, 애플 로그인 구현은 조금 미뤄야 할 것 같아요...!

close #14