### PR TITLE
mod: sonarqube 관련 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.3'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id "org.sonarqube" version "3.3"
 }
 
 group = 'com.project'
@@ -65,4 +66,11 @@ tasks.named('test') {
 
 jar {
 	enabled = false
+}
+
+sonarqube {
+	properties {
+		property "sonar.projectKey", "fora-sonarqube"
+		property "sonar.host.url", "http://3.35.113.133:3000"
+	}
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,6 +19,9 @@ else
   sleep 10
 fi
 
+echo "환경변수 등록" >> /home/ec2-user/deploy.log
+source ~/.bashrc
+
 DEPLOY_JAR=$DEPLOY_PATH$JAR_NAME
 echo "> DEPLOY_JAR 배포"    >> /home/ec2-user/deploy.log
-nohup java -jar $DEPLOY_JAR >> /home/ec2-user/deploy.log 2>/home/ec2-user/deploy_err.log &
+nohup java -jar -Dspring.profiles.active=dev $DEPLOY_JAR >> /home/ec2-user/deploy.log 2>/home/ec2-user/deploy_err.log &


### PR DESCRIPTION
## 💻 구현 내용 
- build.gradle에 sonarqube 관련 설정 추가
`plugins {
	id 'java'
	id 'org.springframework.boot' version '3.2.3'
	id 'io.spring.dependency-management' version '1.1.4'
	id "org.sonarqube" version "3.3"
}`
 -> plugins에 sonarqube 추가

`sonarqube {
	properties {
		property "sonar.projectKey", "fora-sonarqube"
		property "sonar.host.url", "http://3.35.113.133:3000"
	}
}`
-> sonarqube 접근 위한 설정 추가


## 🛠️ 개발 오류 사항

## 🗣️ For 리뷰어
close #(19)