### PR TITLE
Redis 적용 및 테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ dependencies {
 }
 
 tasks.named('test') {
+	useJUnitPlatform {
+		excludeTags 'integration'
+	}
+}
+
+tasks.register('integrationTest', Test) {
 	useJUnitPlatform()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0' //lombok annotation processor와의 충돌 제거
+
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/AuthService.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
         String reissuedAccessToken = jwtService.generateAccessToken(userId, user.getEmail(),
             createAuthorityList(user.getAuthority()));
         String reissuedRefreshToken = jwtService.generateRefreshToken(userId);
-        //TODO: RT 저장 로직 구현
+        jwtService.saveRefreshToken(userId, reissuedRefreshToken);
         return new AuthTokenData(reissuedAccessToken, reissuedRefreshToken);
     }
 
@@ -43,8 +43,8 @@ public class AuthService {
     private void validateRefreshToken(String userId, String refreshToken) {
         boolean isValidExpiry = jwtService.isValidTokenExpiry(refreshToken);
         String parsedUserId = jwtService.getSubject(refreshToken);
-        //TODO: RT 저장 여부 확인
-        if (!isValidExpiry || !Objects.equals(parsedUserId, userId)) {
+        boolean existsSavedRefreshToken = jwtService.existsSavedRefreshToken(userId, refreshToken);
+        if (!isValidExpiry || !Objects.equals(parsedUserId, userId) || !existsSavedRefreshToken) {
             throw new BusinessException(INVALID_AUTH_TOKEN);
         }
     }

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/JwtService.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/JwtService.java
@@ -13,4 +13,7 @@ public interface JwtService {
     boolean isValidTokenForm(String token);
     String getSubject(String token);
     Collection<GrantedAuthority> getAuthorities(String token);
+    void saveRefreshToken(String userId, String refreshToken);
+    void deleteRefreshToken(String userId);
+    boolean existsSavedRefreshToken(String userId, String refreshToken);
 }

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/impl/UserSignUpTokenServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/impl/UserSignUpTokenServiceImpl.java
@@ -21,7 +21,7 @@ public class UserSignUpTokenServiceImpl implements UserSignUpTokenService {
         String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail(),
             AuthorityUtils.createAuthorityList(user.getAuthority()));
         String refreshToken = jwtService.generateRefreshToken(user.getId());
-        //TODO: RT 저장소에 저장
+        jwtService.saveRefreshToken(user.getId(), refreshToken);
         return new SignUpTokenData(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/project/foradhd/domain/auth/handler/JwtLogoutSuccessHandler.java
+++ b/src/main/java/com/project/foradhd/domain/auth/handler/JwtLogoutSuccessHandler.java
@@ -1,9 +1,10 @@
 package com.project.foradhd.domain.auth.handler;
 
-import jakarta.servlet.ServletException;
+import com.project.foradhd.domain.auth.business.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,14 +12,19 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 import org.springframework.stereotype.Component;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
 
+    private final JwtService jwtService;
+
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
-        Authentication authentication) throws IOException, ServletException {
+        Authentication authentication) {
         log.info("Logout Success");
+
+        String userId = (String) authentication.getPrincipal();
+        jwtService.deleteRefreshToken(userId);
         SecurityContextHolder.clearContext();
-        //TODO: RT 저장소에서 삭제
     }
 }

--- a/src/main/java/com/project/foradhd/domain/auth/handler/LoginAuthenticationSuccessHandler.java
+++ b/src/main/java/com/project/foradhd/domain/auth/handler/LoginAuthenticationSuccessHandler.java
@@ -29,8 +29,8 @@ public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessH
         String accessToken = jwtService.generateAccessToken(userDetails.getUserId(), userDetails.getUsername(),
             userDetails.getAuthorities());
         String refreshToken = jwtService.generateRefreshToken(userDetails.getUserId());
+        jwtService.saveRefreshToken(userDetails.getUserId(), refreshToken);
 
-        //TODO: RT 저장소에 저장
         Boolean hasVerifiedEmail = userService.hasVerifiedEmail(userDetails.getUserId());
         LoginResponse loginResponse = new LoginResponse(accessToken, refreshToken, hasVerifiedEmail);
         response.setContentType(APPLICATION_JSON_VALUE);

--- a/src/main/java/com/project/foradhd/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/project/foradhd/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -29,9 +29,9 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         String accessToken = jwtService.generateAccessToken(oAuth2User.getUserId(), oAuth2User.getEmail(),
             oAuth2User.getAuthorities());
         String refreshToken = jwtService.generateRefreshToken(oAuth2User.getUserId());
-
-        //TODO: RT 저장소에 저장
         String userId = oAuth2User.getUserId();
+        jwtService.saveRefreshToken(userId, refreshToken);
+
         Boolean hasVerifiedEmail = userService.hasVerifiedEmail(userId);
         Boolean hasProfile = userService.hasUserProfile(userId);
         OAuth2LoginResponse oAuth2LoginResponse = new OAuth2LoginResponse(accessToken, refreshToken,

--- a/src/main/java/com/project/foradhd/global/config/RedisConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.project.foradhd.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/project/foradhd/global/service/RedisService.java
+++ b/src/main/java/com/project/foradhd/global/service/RedisService.java
@@ -1,0 +1,54 @@
+package com.project.foradhd.global.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public Optional<Object> getValue(String key) {
+        ValueOperations<String, Object> operations = redisTemplate.opsForValue();
+        if (operations.get(key) == null) {
+            return Optional.empty();
+        }
+        return Optional.of(operations.get(key));
+    }
+
+    @Transactional
+    public void setValue(String key, String value, long timeout, TimeUnit unit) {
+        ValueOperations<String, Object> operations = redisTemplate.opsForValue();
+        operations.set(key, value, timeout, unit);
+    }
+
+    @Transactional
+    public void setValue(String key, String value, Duration timeout) {
+        ValueOperations<String, Object> operations = redisTemplate.opsForValue();
+        operations.set(key, value, timeout);
+    }
+
+    @Transactional
+    public void deleteValue(String key) {
+        redisTemplate.delete(key);
+    }
+
+    @Transactional
+    public void expireValue(String key, long timeout, TimeUnit unit) {
+        redisTemplate.expire(key, timeout, unit);
+    }
+
+    @Transactional
+    public void expireValue(String key, Duration timeout) {
+        redisTemplate.expire(key, timeout);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,10 @@ spring:
   config:
     import:
       - application-oauth2.yml
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
 
 jwt:
   expiry:

--- a/src/test/java/com/project/foradhd/ForadhdApplicationTests.java
+++ b/src/test/java/com/project/foradhd/ForadhdApplicationTests.java
@@ -1,8 +1,10 @@
 package com.project.foradhd;
 
+import com.project.foradhd.tags.IntegrationTag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@IntegrationTag
 @SpringBootTest
 class ForadhdApplicationTests {
 

--- a/src/test/java/com/project/foradhd/global/service/RedisServiceTest.java
+++ b/src/test/java/com/project/foradhd/global/service/RedisServiceTest.java
@@ -1,0 +1,109 @@
+package com.project.foradhd.global.service;
+
+import com.project.foradhd.global.config.RedisConfig;
+import com.project.foradhd.tags.IntegrationTag;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@IntegrationTag
+@DisplayName("Redis 서비스 통합 테스트")
+@ExtendWith(SpringExtension.class)
+@Import({RedisProperties.class, RedisConfig.class, RedisService.class})
+class RedisServiceTest {
+
+    @Autowired
+    RedisService redisService;
+
+    static final String KEY = "Spring";
+    static final String VALUE = "Hello World";
+    static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    @BeforeEach
+    void init() {
+        redisService.setValue(KEY, VALUE, TIMEOUT);
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisService.deleteValue(KEY);
+    }
+
+    @DisplayName("Redis에 데이터 저장 후 조회")
+    @Test
+    void get_value_test() {
+        //when
+        Optional<Object> value = redisService.getValue(KEY);
+
+        //then
+        assertThat(value).contains(VALUE);
+    }
+
+    @DisplayName("Redis 데이터 삭제 후 조회")
+    @Test
+    void get_empty_value_test() {
+        //given
+        redisService.deleteValue(KEY);
+
+        //when
+        Optional<Object> value = redisService.getValue(KEY);
+
+        //then
+        assertThat(value).isEmpty();
+    }
+
+    @DisplayName("Redis에 저장 후 만료된 데이터 조회")
+    @Test
+    void get_expired_value_test() {
+        //지연 테스트 위한 Awaitility api 사용 (최대 10초 동안 100ms 마다 조건 만족 여부 체크)
+        await().atMost(10, TimeUnit.SECONDS)
+                .with()
+                .pollDelay(Duration.ofMillis(100))
+                .untilAsserted(() -> {
+                    Optional<Object> value = redisService.getValue(KEY);
+                    assertThat(value).isEmpty();
+                }
+        );
+    }
+
+    @DisplayName("Redis에 저장된 데이터 수정")
+    @Test
+    void update_value_test() {
+        //given
+        String updatedValue = "Hi World";
+        redisService.setValue(KEY, updatedValue, TIMEOUT);
+
+        //when
+        Optional<Object> value = redisService.getValue(KEY);
+
+        //then
+        assertThat(value).contains(updatedValue);
+    }
+
+    @DisplayName("Redis에 저장된 데이터 만료")
+    @Test
+    void expire_value_test() {
+        //given
+        Duration expiredTimeout = Duration.ofSeconds(0);
+        redisService.expireValue(KEY, expiredTimeout);
+
+        //when
+        Optional<Object> value = redisService.getValue(KEY);
+
+        //then
+        assertThat(value).isEmpty();
+    }
+}

--- a/src/test/java/com/project/foradhd/tags/IntegrationTag.java
+++ b/src/test/java/com/project/foradhd/tags/IntegrationTag.java
@@ -1,0 +1,14 @@
+package com.project.foradhd.tags;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Tag("integration")
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IntegrationTag {
+}


### PR DESCRIPTION
## 💻 구현 내용 

- Redis 적용 및 레디스 사용 위한 `RedisService` 구현
- 통합 테스트인 `RedisServiceTest` 작성
- 기존 RT(Refresh Token) 관련 로직에 Redis 적용

## 🗣️ For 리뷰어

- 구현하면서 참고한 [블로그 글](https://green-bin.tistory.com/69)입니다.
- 통합 테스트인 `RedisServiceTest`는 실제 6379 포트에서 Redis가 실행되고 있는 상태여야 테스트에 성공합니다 → 통합 테스트 시에만 `RedisServiceTest` 테스트가 실행되도록 `@IntegrationTag` 커스텀 어노테이션을 정의하고 `RedisServiceTest`에 선언(자세한 내용은 [JUnit5의 @Tag](https://junit.org/junit5/docs/current/user-guide/#writing-tests-tagging-and-filtering) 참고)
  ```java
  @Tag("integration")
  @Target({ElementType.TYPE, ElementType.METHOD})
  @Retention(RetentionPolicy.RUNTIME)
  public @interface IntegrationTag {
  }

  //...

  @IntegrationTag //추가
  @DisplayName("Redis 서비스 통합 테스트")
  @ExtendWith(SpringExtension.class)
  @Import({RedisProperties.class, RedisConfig.class, RedisService.class})
  class RedisServiceTest {
  
    @Autowired
    RedisService redisService;

    //...
  }
  ```
- Gradle의 기존 task인 `test` 실행 시 `@IntegrationTag`가 선언된 테스트는 제외되도록 설정 + `integrationTest` task 실행 시에는 통합 테스트를 포함한 모든 테스트가 실행O (in `build.gradle`)
  ```
  tasks.named('test') {
	  useJUnitPlatform {
		  excludeTags 'integration'
	  }
  }
  
  tasks.register('integrationTest', Test) {
	  useJUnitPlatform()
  }
  ```
- Redis에 저장한 RT 토큰의 만료 테스트 위한 [Awaitility 라이브러리](https://www.baeldung.com/awaitility-testing) 사용
  - `Thread.sleep(7000);`는 고정적으로 7초를 기다려야 하는 반면 아래 `untilAsserted` api를 사용하면 해당 조건이 만족할 때까지 최대 10초 기다리게 됨 
  ```java
  @DisplayName("Redis에 저장 후 만료된 데이터 조회")
  @Test
  void get_expired_value_test() {
      //지연 테스트 위한 Awaitility api 사용 (최대 10초 동안 100ms 마다 조건 만족 여부 체크)
      await().atMost(10, TimeUnit.SECONDS)
              .with()
              .pollDelay(Duration.ofMillis(100))
              .untilAsserted(() -> {
                  Optional<Object> value = redisService.getValue(KEY);
                  assertThat(value).isEmpty();
              }
      );
  }
  ```

close #24 