### PR TITLE
S3 이미지 업로드 및 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	//S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/foradhd/global/config/AwsS3Config.java
+++ b/src/main/java/com/project/foradhd/global/config/AwsS3Config.java
@@ -1,0 +1,27 @@
+package com.project.foradhd.global.config;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        //local 환경: EnvironmentVariableCredentialsProvider 동작 (AWS_ACCESS_KEY_ID, AWS_SECRET_KEY 환경 변수로 credentials 주입)
+        //dev, prd 환경: InstanceProfileCredentialsProvider 동작 (AmazonSESFullAccess 권한을 가진 EC2 IAM Role을 통해 credentials 주입)
+        DefaultAWSCredentialsProviderChain credentialsProvider = new DefaultAWSCredentialsProviderChain();
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(credentialsProvider)
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/project/foradhd/global/exception/ErrorCode.java
+++ b/src/main/java/com/project/foradhd/global/exception/ErrorCode.java
@@ -35,6 +35,13 @@ public enum ErrorCode {
     ALREADY_EXISTS_HOSPITAL_RECEIPT_REVIEW(CONFLICT, "이미 작성한 영수증 리뷰가 있습니다."),
     ALREADY_EXISTS_HOSPITAL_BRIEF_REVIEW(CONFLICT, "이미 작성한 간단 리뷰가 있습니다."),
 
+    //S3
+    EMPTY_FILE(BAD_REQUEST, "유효한 파일이어야 합니다."),
+    NOT_FOUND_FILE_EXTENSION(BAD_REQUEST, "파일 확장자가 존재하지 않습니다."),
+    INVALID_FILE_EXTENSION(BAD_REQUEST, "지원하지 않는 파일 확장자입니다."),
+    INVALID_FILE_SIZE(BAD_REQUEST, "최대 허용 파일 용량을 초과하였습니다."),
+    FILE_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+
     //validation
     INVALID_REQUEST(BAD_REQUEST, "잘못된 요청입니다."),
 

--- a/src/main/java/com/project/foradhd/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/foradhd/global/exception/handler/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
@@ -78,6 +79,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleServletRequestBindingException(ServletRequestBindingException e) {
         log.error("Invalid request", e);
         return ErrorResponse.toResponseEntity(ErrorCode.INVALID_REQUEST);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.error("Uploaded file exceeded maximum size", e);
+        return ErrorResponse.toResponseEntity(ErrorCode.INVALID_FILE_SIZE);
     }
 
     private String generateValidationMessage(Object value, Class<?> targetType, Throwable throwable) {

--- a/src/main/java/com/project/foradhd/global/image/web/controller/ImageUploadController.java
+++ b/src/main/java/com/project/foradhd/global/image/web/controller/ImageUploadController.java
@@ -1,14 +1,12 @@
 package com.project.foradhd.global.image.web.controller;
 
+import com.project.foradhd.global.image.web.dto.request.ImageDeleteRequest;
 import com.project.foradhd.global.image.web.dto.request.ImageUploadRequest;
 import com.project.foradhd.global.image.web.dto.response.ImageUploadResponse;
 import com.project.foradhd.global.service.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -25,5 +23,11 @@ public class ImageUploadController {
                                                             @RequestPart ImageUploadRequest request) {
         List<String> imagePathList = awsS3Service.uploadImages(request.getImagePathPrefix(), imageFileList);
         return ResponseEntity.ok(new ImageUploadResponse(imagePathList));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteImages(@RequestBody ImageDeleteRequest request) {
+        awsS3Service.deleteImages(request.getImagePathList());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/project/foradhd/global/image/web/controller/ImageUploadController.java
+++ b/src/main/java/com/project/foradhd/global/image/web/controller/ImageUploadController.java
@@ -1,0 +1,29 @@
+package com.project.foradhd.global.image.web.controller;
+
+import com.project.foradhd.global.image.web.dto.request.ImageUploadRequest;
+import com.project.foradhd.global.image.web.dto.response.ImageUploadResponse;
+import com.project.foradhd.global.service.AwsS3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/images")
+@RestController
+public class ImageUploadController {
+
+    private final AwsS3Service awsS3Service;
+
+    @PostMapping
+    public ResponseEntity<ImageUploadResponse> uploadImages(@RequestPart List<MultipartFile> imageFileList,
+                                                            @RequestPart ImageUploadRequest request) {
+        List<String> imagePathList = awsS3Service.uploadImages(request.getImagePathPrefix(), imageFileList);
+        return ResponseEntity.ok(new ImageUploadResponse(imagePathList));
+    }
+}

--- a/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageDeleteRequest.java
+++ b/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.global.image.web.dto.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ImageDeleteRequest {
+
+    List<String> imagePathList;
+}

--- a/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageUploadRequest.java
+++ b/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageUploadRequest.java
@@ -1,0 +1,10 @@
+package com.project.foradhd.global.image.web.dto.request;
+
+import com.project.foradhd.global.image.web.enums.ImagePathPrefix;
+import lombok.Getter;
+
+@Getter
+public class ImageUploadRequest {
+
+    ImagePathPrefix imagePathPrefix = ImagePathPrefix.DEFAULT_IMAGE;
+}

--- a/src/main/java/com/project/foradhd/global/image/web/dto/response/ImageUploadResponse.java
+++ b/src/main/java/com/project/foradhd/global/image/web/dto/response/ImageUploadResponse.java
@@ -1,0 +1,13 @@
+package com.project.foradhd.global.image.web.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ImageUploadResponse {
+
+    private List<String> imagePathList;
+}

--- a/src/main/java/com/project/foradhd/global/image/web/enums/ImagePathPrefix.java
+++ b/src/main/java/com/project/foradhd/global/image/web/enums/ImagePathPrefix.java
@@ -1,0 +1,13 @@
+package com.project.foradhd.global.image.web.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImagePathPrefix {
+
+    DEFAULT_IMAGE("image/");
+
+    private final String path;
+}

--- a/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
+++ b/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
@@ -4,6 +4,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.project.foradhd.global.exception.BusinessException;
+import com.project.foradhd.global.exception.ErrorCode;
 import com.project.foradhd.global.image.web.enums.ImagePathPrefix;
 import com.project.foradhd.global.util.ImageUtil;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +40,7 @@ public class AwsS3Service {
 
     private String uploadImage(ImagePathPrefix imagePathPrefix, MultipartFile image) {
         if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
-            throw new RuntimeException();
+            throw new BusinessException(ErrorCode.EMPTY_FILE);
         }
         validateImageFileExtension(image.getOriginalFilename());
         return uploadImageToS3(imagePathPrefix, image);
@@ -54,7 +56,7 @@ public class AwsS3Service {
         boolean isAllowedExtension = ALLOWED_IMAGE_FILE_EXTENSION_LIST.stream()
                 .anyMatch(allowedImageFileExtension -> allowedImageFileExtension.equalsIgnoreCase(fileExtension));
         if (!isAllowedExtension) {
-            throw new RuntimeException();
+            throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION);
         }
     }
 
@@ -70,14 +72,14 @@ public class AwsS3Service {
             amazonS3.putObject(putObjectRequest);
             return amazonS3.getUrl(bucket, imagePath).toString();
         } catch (IOException e) {
-            throw new RuntimeException();
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_ERROR);
         }
     }
 
     private String getFileExtension(String filename) {
         int fileExtensionIndex = filename.lastIndexOf(FILE_EXTENSION_SEPARATOR);
         if (fileExtensionIndex == -1) {
-            throw new RuntimeException();
+            throw new BusinessException(ErrorCode.NOT_FOUND_FILE_EXTENSION);
         }
         return filename.substring(fileExtensionIndex + 1);
     }

--- a/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
+++ b/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
@@ -70,7 +70,7 @@ public class AwsS3Service {
 
             PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, imagePath, inputStream, metadata);
             amazonS3.putObject(putObjectRequest);
-            return amazonS3.getUrl(bucket, imagePath).toString();
+            return imagePath;
         } catch (IOException e) {
             throw new BusinessException(ErrorCode.FILE_UPLOAD_ERROR);
         }

--- a/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
+++ b/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
@@ -31,12 +31,21 @@ public class AwsS3Service {
                 .toList();
     }
 
+    public void deleteImages(List<String> imagePaths) {
+        imagePaths.forEach(this::deleteImage);
+    }
+
     private String uploadImage(ImagePathPrefix imagePathPrefix, MultipartFile image) {
         if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
             throw new RuntimeException();
         }
         validateImageFileExtension(image.getOriginalFilename());
         return uploadImageToS3(imagePathPrefix, image);
+    }
+
+    private void deleteImage(String imagePath) {
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, imagePath);
+        amazonS3.deleteObject(deleteObjectRequest);
     }
 
     private void validateImageFileExtension(String imageFilename) {

--- a/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
+++ b/src/main/java/com/project/foradhd/global/service/AwsS3Service.java
@@ -1,0 +1,80 @@
+package com.project.foradhd.global.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.project.foradhd.global.image.web.enums.ImagePathPrefix;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+@RequiredArgsConstructor
+@Service
+public class AwsS3Service {
+
+    private static final String FILE_EXTENSION_SEPARATOR = ".";
+    private static final List<String> ALLOWED_IMAGE_FILE_EXTENSION_LIST = Arrays.asList("jpg", "jpeg", "png", "gif");
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public List<String> uploadImages(ImagePathPrefix imagePathPrefix, List<MultipartFile> images) {
+        return images.stream()
+                .map(image -> uploadImage(imagePathPrefix, image))
+                .toList();
+    }
+
+    private String uploadImage(ImagePathPrefix imagePathPrefix, MultipartFile image) {
+        if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new RuntimeException();
+        }
+        validateImageFileExtension(image.getOriginalFilename());
+        return uploadImageToS3(imagePathPrefix, image);
+    }
+
+    private void validateImageFileExtension(String imageFilename) {
+        String fileExtension = getFileExtension(imageFilename);
+        boolean isAllowedExtension = ALLOWED_IMAGE_FILE_EXTENSION_LIST.stream()
+                .anyMatch(allowedImageFileExtension -> allowedImageFileExtension.equalsIgnoreCase(fileExtension));
+        if (!isAllowedExtension) {
+            throw new RuntimeException();
+        }
+    }
+
+    private String uploadImageToS3(ImagePathPrefix imagePathPrefix, MultipartFile image) {
+        String randomImageFilename = generateRandomImageFilename(image.getOriginalFilename());
+        String imagePath = imagePathPrefix.getPath() + randomImageFilename;
+        try (InputStream is = image.getInputStream()) {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(image.getContentType());
+            metadata.setContentLength(image.getSize());
+
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, imagePath, is, metadata);
+            amazonS3.putObject(putObjectRequest);
+            return amazonS3.getUrl(bucket, imagePath).toString();
+        } catch (IOException e) {
+            throw new RuntimeException();
+        }
+    }
+
+    private String getFileExtension(String filename) {
+        int fileExtensionIndex = filename.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+        if (fileExtensionIndex == -1) {
+            throw new RuntimeException();
+        }
+        return filename.substring(fileExtensionIndex + 1);
+    }
+
+    private String generateRandomImageFilename(String originalImageFilename) {
+        String fileExtension = getFileExtension(originalImageFilename);
+        return UUID.randomUUID().toString().replace("-", "")
+                + FILE_EXTENSION_SEPARATOR + fileExtension;
+    }
+}

--- a/src/main/java/com/project/foradhd/global/util/ImageUtil.java
+++ b/src/main/java/com/project/foradhd/global/util/ImageUtil.java
@@ -1,0 +1,25 @@
+package com.project.foradhd.global.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+public abstract class ImageUtil {
+
+    public static int[] getImageDimensions(MultipartFile image) {
+        try (InputStream inputStream = image.getInputStream()) {
+            BufferedImage bufferedImage = ImageIO.read(inputStream);
+            int width = bufferedImage.getWidth();
+            int height = bufferedImage.getHeight();
+            return new int[]{width, height};
+        } catch (IOException e) {
+            log.error("Failed to convert MultipartFile to InputStream");
+            return new int[]{0, 0};
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,15 @@ aws:
   ses:
     from: ${AWS_SES_FROM}
 
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false #CloudFormation 스택 수동 관리 설정
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
     redis:
       host: 127.0.0.1
       port: 6379
+  servlet:
+    multipart:
+      max-file-size: 5MB #하나의 파일 용량 제한
+      max-request-size: 10MB #하나의 요청 내 전체 파일 용량 제한
+      resolve-lazily: true #실제 파일에 접근하는 시점에 파일 용량 체크 (스프링 MVC에서 예외 throw)
 
 jwt:
   expiry:


### PR DESCRIPTION
## 💻 구현 내용 

- 프로젝트 전반에서 사용할 이미지 업로드 및 삭제 api 구현하였습니다.

## 🛠️ 개발 오류 사항

### 파일 용량 제한 설정 
```
spring:
  servlet:
    multipart:
      max-file-size: 5MB #하나의 파일 용량 제한
      max-request-size: 10MB #하나의 요청 내 전체 파일 용량 제한
      resolve-lazily: true #실제 파일에 접근하는 시점에 파일 용량 체크 (스프링 MVC에서 예외 throw)
```

- `resolve-lazily: true`는 파일 용량이 제한을 넘는 경우 발생하는 `MaxUploadSizeExceededException` 예외를 `GlobalExceptionHandler`에서 처리하기 위한 설정입니다. [참고](https://www.inflearn.com/questions/810872/%ED%8C%8C%EC%9D%BC-%EC%97%85%EB%A1%9C%EB%93%9C-%ED%81%AC%EA%B8%B0-%EC%A0%9C%ED%95%9C-exception%EC%97%90-%EB%8C%80%ED%95%B4-%EC%A7%88%EB%AC%B8%EB%93%9C%EB%A6%BD%EB%8B%88%EB%8B%A4)
- 업로드 가능한 파일 1개의 최대 사이즈는 5MB, 하나의 요청으로 여러 개의 파일을 업로드하는 경우 총 용량은 최대 10MB까지 가능합니다. 만약 용량 제한을 풀어야 하는 경우 해당 부분 수정하면 됩니다.  

## 🗣️ For 리뷰어

### 개발, 운영 환경에 따라 버킷 분리
- 개발 환경에서는 `fora-dev` 버킷을, 운영 환경에서는 `fora-prd` 버킷을 사용합니다. 따라서 각 환경에 맞게 `AWS_S3_BUCKET` 환경 변수값을 각각 fora-dev 또는 fora-prd로 설정해주어야 합니다. 

### 이미지 종류에 따라 폴더 분리

- 저장되는 이미지의 종류(ex. 유저 프로필 이미지, 게시글 이미지 등)에 따라 저장 폴더를 분리하기 위해 경로 prefix를 다음 enum에서 관리하며, 이미지 업로드 요청 시 해당 값을 전달합니다. (아래 스크린샷처럼 요청해주세요. 참고로 요청 시 토큰 필요합니다.)
  ```java
  @Getter
  @RequiredArgsConstructor
  public enum ImagePathPrefix {
  
      DEFAULT_IMAGE("image/");
  
      private final String path;
  }
  ```
  <img width="1254" src="https://github.com/team-forAdhd/forAdhd-server/assets/65665065/39c27a4e-7829-4a64-bcf8-b07baced08f4">
  
- 다음과 같이 `fora-dev/image` 아래 저장됩니다. 이미지 관리를 위해 폴더 구분이 필요하다면 폴더 생성 후 `ImagePathPrefix` enum도 업데이트해주세요.
  <img width="1381" src="https://github.com/team-forAdhd/forAdhd-server/assets/65665065/81bab2e9-809b-40c4-9f14-d63b7f253a0f">

### CloudFront 사용을 위한 이미지 경로 반환

- 이미지 업로드 후 `https://fora-dev.s3.ap-northeast-2.amazonaws.com/image/0cd89fde4d6e45178812b432123e648d_259x320.png` 와 같이 전체 URL이 아닌 `image/0cd89fde4d6e45178812b432123e648d_259x320.png` 와 같은 부분 경로만 반환됩니다. 이는 S3 객체에 직접 접근하는 것보다는 CloudFront를 통해 접근하는 것이 비용 절감 + 접근 속도 향상 측면에서 더 좋은 것으로 알고 있습니다.([관련 문서](https://aws.amazon.com/ko/blogs/korea/amazon-s3-amazon-cloudfront-a-match-made-in-the-cloud/)) ~~이 경우 EC2가 떠 있어야 하며 관련 내용 공부도 필요하여 아직은 미구현 상태입니다. 혹시 이미지 업로드 업로드 후 객체에 직접 접근하고 싶다면 앞에 s3 경로 붙여주시면 됩니다.~~

- https://d37m2jfdnaemwx.cloudfront.net/image/355adf940d4f4a809c2793fe9964c69d_259x320.png (CloudFront를 통한 이미지 접근) / https://fora-dev.s3.ap-northeast-2.amazonaws.com/image/355adf940d4f4a809c2793fe9964c69d_259x320.png (S3에 직접 이미지 접근)
  => 두번째의 경우 AccessDenied 에러 발생합니다.(퍼블릭 엑세스 차단 활성화하고, CloudFront를 통해서만 접근 가능하도록 설정했기 때문) 따라서 이미지 업로드 api 호출 후 응답으로 전달되는 경로에 CloudFront 배포 도메인(https://d37m2jfdnaemwx.cloudfront.net/) 붙여서 호출해야 합니다.

[참고](https://velog.io/@nyoung215/Spring-S3-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%97%85%EB%A1%9C%EB%93%9C%ED%95%98%EA%B8%B0#%EB%B2%84%ED%82%B7-%EC%83%9D%EC%84%B1)
[참고2](https://innovation123.tistory.com/197#S3%EC%97%90%20%EC%9D%B4%EB%AF%B8%EC%A7%80%20%EC%97%85%EB%A1%9C%EB%93%9C%20%EA%B0%9C%EB%85%90-1)
[참고3](https://velog.io/@rungoat/AWS-S3%EC%99%80-CloudFront-%EC%97%B0%EB%8F%99%ED%95%98%EA%B8%B0)

close #31 