### PR TITLE
애플 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 *.pem
 *.ppk
+
+src/main/resources/static/keys/**

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,10 @@ dependencies {
 
 	//S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//암호화(PEM 키)
+	implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+	implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/AppleIdTokenValidator.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/AppleIdTokenValidator.java
@@ -1,0 +1,64 @@
+package com.project.foradhd.domain.auth.business.service;
+
+import com.project.foradhd.domain.auth.web.client.ApplePublicKeyClient;
+import com.project.foradhd.domain.auth.web.dto.response.ApplePublicKeyListResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.IncorrectClaimException;
+import io.jsonwebtoken.impl.DefaultJwsHeader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class AppleIdTokenValidator {
+
+    public static final String NONCE_SUPPORTED_CLAIM_KEY = "nonce_supported";
+    private final ApplePublicKeyClient applePublicKeyClient;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final JwtService jwtService;
+
+    @Value("${apple.url}")
+    private String APPLE_URL;
+
+    @Value("${apple.client-id}")
+    private String APPLE_CLIENT_ID;
+
+    public void validate(String idToken) {
+        Map<String, Object> decodedHeader = jwtService.decodeHeader(idToken);
+        DefaultJwsHeader jwtHeader = new DefaultJwsHeader(decodedHeader);
+        PublicKey publicKey = getApplePublicKey(decodedHeader);
+
+        //Verify the JWS E256 signature using the server’s public key
+        //Verify that the time is earlier than the exp value of the token
+        jwtService.validateTokenExpiry(idToken, publicKey);
+        Claims claims = jwtService.parseToken(idToken, publicKey);
+
+        //Verify the nonce for the authentication → "nonce_supported": true
+        Boolean nonceSupported = claims.get(NONCE_SUPPORTED_CLAIM_KEY, Boolean.class);
+        if (!nonceSupported) {
+            throw new IncorrectClaimException(jwtHeader, claims,
+                    "Invalid Apple Id Token: nonce_supported = " + nonceSupported);
+        }
+
+        //Verify that the iss field contains https://appleid.apple.com → "iss": "https://appleid.apple.com"
+        String issuer = claims.getIssuer();
+        if (!issuer.equals(APPLE_URL)) {
+            throw new IncorrectClaimException(jwtHeader, claims, "Invalid Apple Id Token: issuer = " + issuer);
+        }
+
+        //Verify that the aud field is the developer’s client_id → "aud": ${APPLE_CLIENT_ID}
+        String audience = claims.getAudience();
+        if (!audience.equals(APPLE_CLIENT_ID)) {
+            throw new IncorrectClaimException(jwtHeader, claims, "Invalid Apple Id Token: audience = " + audience);
+        }
+    }
+
+    private PublicKey getApplePublicKey(Map<String, Object> headers) {
+        ApplePublicKeyListResponse applePublicKeyListResponse = applePublicKeyClient.getApplePublicKeyList();
+        return applePublicKeyGenerator.generatePublicKey(headers, applePublicKeyListResponse);
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/AppleIdTokenValidator.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/AppleIdTokenValidator.java
@@ -27,6 +27,7 @@ public class AppleIdTokenValidator {
     @Value("${apple.client-id}")
     private String APPLE_CLIENT_ID;
 
+    //참고: https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user/
     public void validate(String idToken) {
         Map<String, Object> decodedHeader = jwtService.decodeHeader(idToken);
         DefaultJwsHeader jwtHeader = new DefaultJwsHeader(decodedHeader);
@@ -57,6 +58,7 @@ public class AppleIdTokenValidator {
         }
     }
 
+    //참고: https://developer.apple.com/documentation/sign_in_with_apple/fetch_apple_s_public_key_for_verifying_token_signature
     private PublicKey getApplePublicKey(Map<String, Object> headers) {
         ApplePublicKeyListResponse applePublicKeyListResponse = applePublicKeyClient.getApplePublicKeyList();
         return applePublicKeyGenerator.generatePublicKey(headers, applePublicKeyListResponse);

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/ApplePublicKeyGenerator.java
@@ -1,0 +1,52 @@
+package com.project.foradhd.domain.auth.business.service;
+
+import com.project.foradhd.domain.auth.web.dto.response.ApplePublicKeyListResponse;
+import com.project.foradhd.domain.auth.web.dto.response.ApplePublicKeyListResponse.ApplePublicKeyResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class ApplePublicKeyGenerator {
+
+    private static final String KID_HEADER = "kid";
+    private static final String ALG_HEADER = "alg";
+
+    public PublicKey generatePublicKey(Map<String, Object> headers,
+                                    ApplePublicKeyListResponse applePublicKeyList) {
+        String kid = (String) headers.get(KID_HEADER);
+        String alg = (String) headers.get(ALG_HEADER);
+        ApplePublicKeyResponse applePublicKey = getMatchedPublicKey(kid, alg, applePublicKeyList);
+        return getPublicKey(applePublicKey);
+    }
+
+    private ApplePublicKeyResponse getMatchedPublicKey(String kid, String alg, ApplePublicKeyListResponse applePublicKeyList) {
+        return applePublicKeyList.keys().stream()
+                .filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+                .findFirst()
+                .orElseThrow(() -> new BadCredentialsException("Invalid Apple Public Keys"));
+    }
+
+    private PublicKey getPublicKey(ApplePublicKeyResponse applePublicKey) {
+        byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.e());
+
+        try {
+            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(new BigInteger(1, nBytes), new BigInteger(1, eBytes));
+            KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.kty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/JwtService.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/JwtService.java
@@ -1,6 +1,10 @@
 package com.project.foradhd.domain.auth.business.service;
 
+import java.security.Key;
 import java.util.Collection;
+import java.util.Map;
+
+import io.jsonwebtoken.Claims;
 import org.springframework.security.core.GrantedAuthority;
 
 public interface JwtService {
@@ -8,11 +12,16 @@ public interface JwtService {
     String generateAccessToken(String userId, String email, Collection<GrantedAuthority> authorities);
     String generateRefreshToken(String userId);
     void validateTokenExpiry(String token);
+    void validateTokenExpiry(String token, Key key);
     void validateTokenForm(String token);
     boolean isValidTokenExpiry(String token);
     boolean isValidTokenForm(String token);
     String getSubject(String token);
     Collection<GrantedAuthority> getAuthorities(String token);
+    Map<String, Object> decodeHeader(String token);
+    Map<String, Object> decodePayload(String token);
+    Claims parseToken(String token, Key key);
+    Claims parseExpiredToken(String token, Key key);
     void saveRefreshToken(String userId, String refreshToken);
     void deleteRefreshToken(String userId);
     boolean existsSavedRefreshToken(String userId, String refreshToken);

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/impl/AppleOAuth2UserAttributesServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/impl/AppleOAuth2UserAttributesServiceImpl.java
@@ -1,34 +1,32 @@
 package com.project.foradhd.domain.auth.business.service.impl;
 
+import com.project.foradhd.domain.auth.business.service.AppleIdTokenValidator;
+import com.project.foradhd.domain.auth.business.service.JwtService;
 import com.project.foradhd.domain.auth.business.service.OAuth2UserAttributesService;
-import com.project.foradhd.global.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Map;
 
 import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames.ID_TOKEN;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class AppleOAuth2UserAttributesServiceImpl implements OAuth2UserAttributesService {
+
+    private final AppleIdTokenValidator appleIdTokenValidator;
+    private final JwtService jwtService;
 
     @Override
     public Map<String, Object> getAttributes(OAuth2UserRequest oAuth2UserRequest, Map<String, Object> attributes) {
         String idToken = oAuth2UserRequest.getAdditionalParameters().get(ID_TOKEN).toString();
-        attributes.putAll(decodeIdToken(idToken));
+        appleIdTokenValidator.validate(idToken);
+
+        Map<String, Object> decodedPayload = jwtService.decodePayload(idToken);
+        attributes.putAll(decodedPayload);
         return attributes;
-    }
-
-    public Map<String, Object> decodeIdToken(String idToken) {
-        String[] encodedPayload = idToken.split("\\.");
-        Base64.Decoder decoder = Base64.getUrlDecoder();
-
-        byte[] decodedBytes = decoder.decode(encodedPayload[1].getBytes(StandardCharsets.UTF_8));
-        String decodedPayload = new String(decodedBytes, StandardCharsets.UTF_8);
-        return JsonUtil.readValue(decodedPayload, Map.class);
     }
 }

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/impl/AppleOAuth2UserAttributesServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/impl/AppleOAuth2UserAttributesServiceImpl.java
@@ -1,16 +1,34 @@
 package com.project.foradhd.domain.auth.business.service.impl;
 
 import com.project.foradhd.domain.auth.business.service.OAuth2UserAttributesService;
+import com.project.foradhd.global.util.JsonUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
+import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames.ID_TOKEN;
+
+@Slf4j
 @Service
 public class AppleOAuth2UserAttributesServiceImpl implements OAuth2UserAttributesService {
 
     @Override
     public Map<String, Object> getAttributes(OAuth2UserRequest oAuth2UserRequest, Map<String, Object> attributes) {
-        return null;
+        String idToken = oAuth2UserRequest.getAdditionalParameters().get(ID_TOKEN).toString();
+        attributes.putAll(decodeIdToken(idToken));
+        return attributes;
+    }
+
+    public Map<String, Object> decodeIdToken(String idToken) {
+        String[] encodedPayload = idToken.split("\\.");
+        Base64.Decoder decoder = Base64.getUrlDecoder();
+
+        byte[] decodedBytes = decoder.decode(encodedPayload[1].getBytes(StandardCharsets.UTF_8));
+        String decodedPayload = new String(decodedBytes, StandardCharsets.UTF_8);
+        return JsonUtil.readValue(decodedPayload, Map.class);
     }
 }

--- a/src/main/java/com/project/foradhd/domain/auth/business/service/impl/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/service/impl/OAuth2UserServiceImpl.java
@@ -33,11 +33,10 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
     @Transactional
     @Override
     public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
-        OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
         String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
         String nameAttributeKey = oAuth2UserRequest.getClientRegistration().getProviderDetails()
             .getUserInfoEndpoint().getUserNameAttributeName();
-        Map<String, Object> attributes = oAuth2UserInfoService.getAttributes(oAuth2UserRequest, oAuth2User);
+        Map<String, Object> attributes = oAuth2UserInfoService.getAttributes(oAuth2UserRequest, super::loadUser);
 
         OAuth2Attributes oAuth2Attributes = OAuth2AttributesFactory.valueOf(registrationId, nameAttributeKey, attributes);
         User user = getSocialLoginedUser(oAuth2Attributes);

--- a/src/main/java/com/project/foradhd/domain/auth/business/userdetails/impl/AppleOAuth2Attributes.java
+++ b/src/main/java/com/project/foradhd/domain/auth/business/userdetails/impl/AppleOAuth2Attributes.java
@@ -1,14 +1,44 @@
 package com.project.foradhd.domain.auth.business.userdetails.impl;
 
 import com.project.foradhd.domain.auth.business.userdetails.OAuth2Attributes;
+
+import java.time.LocalDate;
 import java.util.Map;
+
+import com.project.foradhd.domain.user.persistence.enums.Gender;
+import com.project.foradhd.domain.user.persistence.enums.Provider;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AppleOAuth2Attributes extends OAuth2Attributes {
 
+    private static final String ID_KEY = "sub";
+    private static final String EMAIL_VERIFIED_KEY = "email_verified";
+    private static final String EMAIL_KEY = "email";
+
     public static OAuth2Attributes of(String nameAttributesKey, Map<String, Object> attributes) {
-        return null;
+        return GoogleOAuth2Attributes.builder()
+                .id(parseId(attributes))
+                .name("")
+                .email(parseEmail(attributes))
+                .isVerifiedEmail(parseIsVerifiedEmail(attributes))
+                .gender(Gender.UNKNOWN)
+                .ageRange("")
+                .birth(LocalDate.now())
+                .provider(Provider.APPLE)
+                .build();
+    }
+
+    private static String parseId(Map<String, Object> attributes) {
+        return String.valueOf(attributes.get(ID_KEY));
+    }
+
+    private static String parseEmail(Map<String, Object> attributes) {
+        return String.valueOf(attributes.get(EMAIL_KEY));
+    }
+
+    private static Boolean parseIsVerifiedEmail(Map<String, Object> attributes) {
+        return (boolean) attributes.get(EMAIL_VERIFIED_KEY);
     }
 }

--- a/src/main/java/com/project/foradhd/domain/auth/converter/CustomOAuth2AuthorizationCodeGrantRequestEntityConverter.java
+++ b/src/main/java/com/project/foradhd/domain/auth/converter/CustomOAuth2AuthorizationCodeGrantRequestEntityConverter.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 public class CustomOAuth2AuthorizationCodeGrantRequestEntityConverter
         implements Converter<OAuth2AuthorizationCodeGrantRequest, RequestEntity<?>> {
 
-    private static final int CLIENT_SECRET_EXPIRY_MONTH = 6;
+    private static final int CLIENT_SECRET_EXPIRY_MONTH = 3;
 
     @Value("${apple.url}")
     private String APPLE_URL;

--- a/src/main/java/com/project/foradhd/domain/auth/converter/CustomOAuth2AuthorizationCodeGrantRequestEntityConverter.java
+++ b/src/main/java/com/project/foradhd/domain/auth/converter/CustomOAuth2AuthorizationCodeGrantRequestEntityConverter.java
@@ -1,0 +1,107 @@
+package com.project.foradhd.domain.auth.converter;
+
+import com.project.foradhd.domain.user.persistence.enums.Provider;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.impl.DefaultJwsHeader;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.RequestEntity;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequestEntityConverter;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+//Authorization Code 발급 응답 → Access Token 발급을 위한 요청 객체 생성하는 converter
+@Slf4j
+@Component
+public class CustomOAuth2AuthorizationCodeGrantRequestEntityConverter
+        implements Converter<OAuth2AuthorizationCodeGrantRequest, RequestEntity<?>> {
+
+    private static final int CLIENT_SECRET_EXPIRY_MONTH = 6;
+
+    @Value("${apple.url}")
+    private String APPLE_URL;
+
+    @Value("${apple.key-path}")
+    private String APPLE_KEY_PATH;
+
+    @Value("${apple.client-id}")
+    private String APPLE_CLIENT_ID;
+
+    @Value("${apple.team-id}")
+    private String APPLE_TEAM_ID;
+
+    @Value("${apple.key-id}")
+    private String APPLE_KEY_ID;
+
+    private OAuth2AuthorizationCodeGrantRequestEntityConverter defaultConverter;
+
+    public CustomOAuth2AuthorizationCodeGrantRequestEntityConverter() {
+        this.defaultConverter = new OAuth2AuthorizationCodeGrantRequestEntityConverter();
+    }
+
+    @Override
+    public RequestEntity<?> convert(OAuth2AuthorizationCodeGrantRequest request) {
+        RequestEntity<?> requestEntity = defaultConverter.convert(request);
+        String registrationId = request.getClientRegistration().getRegistrationId();
+        Optional<Provider> optionalProvider = Provider.from(registrationId);
+        MultiValueMap<String, String> body = (MultiValueMap<String, String>) requestEntity.getBody();
+        if (optionalProvider.isPresent() && optionalProvider.get() == Provider.APPLE) {
+            body.set(OAuth2ParameterNames.CLIENT_SECRET, createClientSecret());
+        }
+        return new RequestEntity<>(body, requestEntity.getHeaders(), requestEntity.getMethod(), requestEntity.getUrl());
+    }
+
+    //참고: https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret
+    public String createClientSecret() {
+        Instant now = Instant.now();
+        Date issuedAt = Date.from(now);
+        Date expiration = Date.from(now.atZone(ZoneOffset.UTC).plusMonths(CLIENT_SECRET_EXPIRY_MONTH).toInstant());
+        Map<String, Object> header = new HashMap<>();
+        header.put(DefaultJwsHeader.ALGORITHM, JwsAlgorithms.ES256);
+        header.put(DefaultJwsHeader.KEY_ID, APPLE_KEY_ID);
+
+        return Jwts.builder()
+                .setHeaderParams(header)
+                .setIssuer(APPLE_TEAM_ID)
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiration)
+                .setAudience(APPLE_URL)
+                .setSubject(APPLE_CLIENT_ID)
+                .signWith(getPrivateKey())
+                .compact();
+    }
+
+    public PrivateKey getPrivateKey() {
+        ClassPathResource resource = new ClassPathResource(APPLE_KEY_PATH);
+        try (InputStream inputStream = resource.getInputStream();
+            PEMParser pemParser = new PEMParser(new StringReader(IOUtils.toString(inputStream, StandardCharsets.UTF_8)))) {
+            PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(pemParser.readObject());
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            return converter.getPrivateKey(privateKeyInfo);
+        } catch (IOException e) {
+            log.error("Apple Key Parsing Error", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/auth/persistence/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/project/foradhd/domain/auth/persistence/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,68 @@
+package com.project.foradhd.domain.auth.persistence.repository;
+
+import com.project.foradhd.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String DEFAULT_AUTHORIZATION_REQUEST_ATTR_NAME = HttpCookieOAuth2AuthorizationRequestRepository.class
+            .getName() + ".AUTHORIZATION_REQUEST";
+
+    private final String cookieName = DEFAULT_AUTHORIZATION_REQUEST_ATTR_NAME;
+
+    private static final int AUTHORIZATION_REQUEST_EXPIRY_SECONDS = 10 * 60;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Assert.notNull(request, "request cannot be null");
+        String stateParameter = getStateParameter(request);
+        if (stateParameter == null) {
+            return null;
+        }
+        OAuth2AuthorizationRequest authorizationRequest = getAuthorizationRequest(request);
+        return (authorizationRequest != null && stateParameter.equals(authorizationRequest.getState()))
+                ? authorizationRequest : null;
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+                                        HttpServletResponse response) {
+        Assert.notNull(request, "request cannot be null");
+        Assert.notNull(response, "response cannot be null");
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+        String state = authorizationRequest.getState();
+        Assert.hasText(state, "authorizationRequest.state cannot be empty");
+        CookieUtil.addCookie(response, cookieName, CookieUtil.serialize(authorizationRequest), AUTHORIZATION_REQUEST_EXPIRY_SECONDS);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                HttpServletResponse response) {
+        Assert.notNull(response, "response cannot be null");
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+        if (authorizationRequest != null) {
+            CookieUtil.deleteCookie(request, response, cookieName);
+        }
+        return authorizationRequest;
+    }
+
+    private String getStateParameter(HttpServletRequest request) {
+        return request.getParameter(OAuth2ParameterNames.STATE);
+    }
+
+    private OAuth2AuthorizationRequest getAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtil.getCookie(request, cookieName)
+                .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/auth/web/client/ApplePublicKeyClient.java
+++ b/src/main/java/com/project/foradhd/domain/auth/web/client/ApplePublicKeyClient.java
@@ -1,0 +1,12 @@
+package com.project.foradhd.domain.auth.web.client;
+
+import com.project.foradhd.domain.auth.web.dto.response.ApplePublicKeyListResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "applePublicKeyClient", url = "${spring.security.oauth2.client.provider.apple.public-key-uri}")
+public interface ApplePublicKeyClient {
+
+    @GetMapping
+    ApplePublicKeyListResponse getApplePublicKeyList();
+}

--- a/src/main/java/com/project/foradhd/domain/auth/web/dto/response/ApplePublicKeyListResponse.java
+++ b/src/main/java/com/project/foradhd/domain/auth/web/dto/response/ApplePublicKeyListResponse.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.auth.web.dto.response;
+
+import java.util.List;
+
+public record ApplePublicKeyListResponse(List<ApplePublicKeyResponse> keys) {
+
+    public record ApplePublicKeyResponse(String kty, String kid, String use,
+                                        String alg, String n, String e) {
+
+    }
+}

--- a/src/main/java/com/project/foradhd/global/config/FeignConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/FeignConfig.java
@@ -1,10 +1,17 @@
 package com.project.foradhd.global.config;
 
 import com.project.foradhd.ForadhdApplication;
+import feign.Retryer;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @EnableFeignClients(basePackageClasses = ForadhdApplication.class)
 @Configuration
 public class FeignConfig {
+
+    @Bean
+    public Retryer retryer() {
+        return new Retryer.Default(1000, 1500, 1);
+    }
 }

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -34,6 +34,8 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResp
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -68,6 +70,7 @@ public class SecurityConfig {
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
     private final CustomOAuth2AuthorizationCodeGrantRequestEntityConverter customOAuth2AuthorizationCodeGrantRequestEntityConverter;
 
     @Bean
@@ -87,6 +90,8 @@ public class SecurityConfig {
             .oauth2Login(config -> config
                 .successHandler(oAuth2AuthenticationSuccessHandler)
                 .failureHandler(oAuth2AuthenticationFailureHandler)
+                .authorizationEndpoint(endPointConfig -> endPointConfig
+                    .authorizationRequestRepository(authorizationRequestRepository))
                 .tokenEndpoint(endPointConfig -> endPointConfig
                     .accessTokenResponseClient(accessTokenResponseClient()))
                 .userInfoEndpoint(endPointConfig -> endPointConfig

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.project.foradhd.global.config;
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.POST;
 
+import com.project.foradhd.domain.auth.converter.CustomOAuth2AuthorizationCodeGrantRequestEntityConverter;
 import com.project.foradhd.domain.auth.filter.JwtAuthenticationFilter;
 import com.project.foradhd.domain.auth.filter.LoginAuthenticationFilter;
 import com.project.foradhd.domain.auth.handler.JwtAuthenticationFailureHandler;
@@ -28,6 +29,9 @@ import org.springframework.security.config.annotation.web.configurers.CsrfConfig
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -64,6 +68,7 @@ public class SecurityConfig {
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final CustomOAuth2AuthorizationCodeGrantRequestEntityConverter customOAuth2AuthorizationCodeGrantRequestEntityConverter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -82,6 +87,8 @@ public class SecurityConfig {
             .oauth2Login(config -> config
                 .successHandler(oAuth2AuthenticationSuccessHandler)
                 .failureHandler(oAuth2AuthenticationFailureHandler)
+                .tokenEndpoint(endPointConfig -> endPointConfig
+                    .accessTokenResponseClient(accessTokenResponseClient()))
                 .userInfoEndpoint(endPointConfig -> endPointConfig
                     .userService(oAuth2UserService)))
             .logout(config -> config
@@ -124,5 +131,12 @@ public class SecurityConfig {
         DefaultMethodSecurityExpressionHandler methodSecurityExpressionHandler = new DefaultMethodSecurityExpressionHandler();
         methodSecurityExpressionHandler.setRoleHierarchy(roleHierarchy);
         return methodSecurityExpressionHandler;
+    }
+
+    @Bean
+    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient() {
+        DefaultAuthorizationCodeTokenResponseClient oAuth2AccessTokenResponseClient = new DefaultAuthorizationCodeTokenResponseClient();
+        oAuth2AccessTokenResponseClient.setRequestEntityConverter(customOAuth2AuthorizationCodeGrantRequestEntityConverter);
+        return oAuth2AccessTokenResponseClient;
     }
 }

--- a/src/main/java/com/project/foradhd/global/util/CookieUtil.java
+++ b/src/main/java/com/project/foradhd/global/util/CookieUtil.java
@@ -1,0 +1,48 @@
+package com.project.foradhd.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+public abstract class CookieUtil {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int expiry) {
+        Cookie cookie = new Cookie(name, value);
+
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(expiry);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst()
+                .ifPresent(cookie -> {
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                });
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> clazz) {
+        return clazz.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -7,7 +7,7 @@ spring:
             client-id: ENC(9Z6DKoVAi506YeSk/5sn+HjZ4zTtvbSciOFtWlKXSk1mmkvRZolPniTRNbGgDLz9)
             client-secret: ENC(BBNo5ldktHfZhnmLejtKHCGjGWLHFu9iD7doNKrWz/2MNYjuNxFQe+9AB+FqA2XL)
             client-authentication-method: client_secret_post
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-name: Kakao
             scope:
@@ -21,7 +21,7 @@ spring:
             client-id: ENC(FGYIfJlxdtT4NyOxnV80uuttXOM8NI1FUcsBqSyUmtk=)
             client-secret: ENC(9y68M+H96/5a0h6oX1zgAKCC27yBO5ll)
             client-authentication-method: client_secret_post
-            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            redirect-uri: ${NAVER_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-name: Naver
             scope:
@@ -43,7 +43,7 @@ spring:
           apple:
             client-id: ENC(VS8LFA0hL4ni+mPBHg78TtsQF4B6wB62JEbo7NMT3k8=)
             client-authentication-method: client_secret_post
-            redirect-uri: https://0924-222-121-219-187.ngrok-free.app/login/oauth2/code/apple
+            redirect-uri: ${APPLE_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-name: Apple
             scope:

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -63,8 +63,9 @@ spring:
             user-info-authentication-method: header
             user-name-attribute: response
           apple:
-            authorizationUri: https://appleid.apple.com/auth/oauth2/v2/authorize?response_mode=form_post
-            tokenUri: https://appleid.apple.com/auth/oauth2/v2/token
+            authorizationUri: https://appleid.apple.com/auth/authorize?response_mode=form_post
+            tokenUri: https://appleid.apple.com/auth/token
+            user-name-attribute: sub
 
 apple:
   url: ${APPLE_URL}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -43,7 +43,7 @@ spring:
           apple:
             client-id: ENC(VS8LFA0hL4ni+mPBHg78TtsQF4B6wB62JEbo7NMT3k8=)
             client-authentication-method: client_secret_post
-            redirect-uri: http://localhost:8080/login/oauth2/code/apple
+            redirect-uri: https://0924-222-121-219-187.ngrok-free.app/login/oauth2/code/apple
             authorization-grant-type: authorization_code
             client-name: Apple
             scope:
@@ -63,8 +63,9 @@ spring:
             user-info-authentication-method: header
             user-name-attribute: response
           apple:
-            authorizationUri: https://appleid.apple.com/auth/authorize?response_mode=form_post
-            tokenUri: https://appleid.apple.com/auth/token
+            authorization-uri: https://appleid.apple.com/auth/authorize?response_mode=form_post
+            token-uri: https://appleid.apple.com/auth/token
+            public-key-uri: https://appleid.apple.com/auth/keys
             user-name-attribute: sub
 
 apple:

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -63,5 +63,12 @@ spring:
             user-info-authentication-method: header
             user-name-attribute: response
           apple:
-            authorizationUri: https://appleid.apple.com/auth/oauth2/v2/authorize
+            authorizationUri: https://appleid.apple.com/auth/oauth2/v2/authorize?response_mode=form_post
             tokenUri: https://appleid.apple.com/auth/oauth2/v2/token
+
+apple:
+  url: ${APPLE_URL}
+  key-path: ${APPLE_KEY_PATH}
+  client-id: ${APPLE_CLIENT_ID}
+  team-id: ${APPLE_TEAM_ID}
+  key-id: ${APPLE_KEY_ID}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -40,6 +40,15 @@ spring:
               - https://www.googleapis.com/auth/user.birthday.read
               - https://www.googleapis.com/auth/profile.agerange.read
               - https://www.googleapis.com/auth/user.gender.read
+          apple:
+            client-id: ENC(VS8LFA0hL4ni+mPBHg78TtsQF4B6wB62JEbo7NMT3k8=)
+            client-authentication-method: client_secret_post
+            redirect-uri: http://localhost:8080/login/oauth2/code/apple
+            authorization-grant-type: authorization_code
+            client-name: Apple
+            scope:
+              - name
+              - email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
@@ -53,3 +62,6 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-info-authentication-method: header
             user-name-attribute: response
+          apple:
+            authorizationUri: https://appleid.apple.com/auth/oauth2/v2/authorize
+            tokenUri: https://appleid.apple.com/auth/oauth2/v2/token

--- a/src/test/java/com/project/foradhd/domain/auth/business/service/impl/OAuth2UserServiceTest.java
+++ b/src/test/java/com/project/foradhd/domain/auth/business/service/impl/OAuth2UserServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import com.project.foradhd.domain.auth.business.service.OAuth2UserInfoService;
 import com.project.foradhd.domain.auth.business.userdetails.OAuth2Attributes;
 import com.project.foradhd.domain.auth.persistence.entity.AuthSocialLogin;
 import com.project.foradhd.domain.auth.persistence.repository.AuthSocialLoginRepository;
@@ -36,6 +37,9 @@ class OAuth2UserServiceTest {
 
     @Mock
     UserService userService;
+
+    @Mock
+    OAuth2UserInfoService oAuth2UserInfoService;
 
     @Mock
     AuthSocialLoginRepository authSocialLoginRepository;


### PR DESCRIPTION
## 💻 구현 내용 

### 애플 로그인 구현
![spring-oauth2-flow](https://github.com/team-forAdhd/forAdhd-server/assets/65665065/eac4d9b3-d7ad-4e8c-a028-ddae0a8c97a1)

- 애플 로그인의 경우, 네이버, 구글 등 기존 소셜 로그인과는 로직이 조금 다름
- `{host}/oauth2/authorization/apple` 요청 시 `OAuth2LoginAuthenticationFilter`로 발급된 Auth Code와 함께 redirect
- `OAuth2AuthorizationCodeAuthenticationProvider`에서 (유저 정보를 조회하기 위해) AT, RT 발급 API 호출위해 `OAuth2AccessTokenResponseClient`의 구현체인 `DefaultAuthorizationCodeTokenResponseClient` 의존
- `DefaultAuthorizationCodeTokenResponseClient`는 이전에 발급 받은 Auth Code와 application-oauth2.yml에 설정된 정보를 가지고 AT, RT 요청 위한 `RequestEntity` 객체를 생성하기 위해 `Converter`(`Converter<OAuth2AuthorizationCodeGrantRequest, RequestEntity<?>>` 구현체)를 다시 의존

⁉️ 네이버, 카카오, 구글의 경우 `client-secret` 값이 고정되어 있기 때문에 application-oauth2.yml에 설정된 값을 읽어와 적절한 `RequestEntity` 객체를 스프링이 알아서 생성해주어 별도 설정 필요 없음(기본적으로 `ClientAuthenticationMethodValidatingRequestEntityConverter` 객체 의존), but 애플의 경우 `team-id`, `key-id`, `client-id` 등의 값을 가지고 JWT 형식의 `client-secret` 을 직접 생성 후 요청해야 함 → 커스텀 `Converter` 정의(`SecurityConfig` 내에서 `accessTokenResponseClient` 빈 등록한 부분 참고)

```java
//Authorization Code 발급 응답 → Access Token 발급을 위한 요청 객체 생성하는 converter
@Slf4j
@Component
public class CustomOAuth2AuthorizationCodeGrantRequestEntityConverter
        implements Converter<OAuth2AuthorizationCodeGrantRequest, RequestEntity<?>> {

    private static final int CLIENT_SECRET_EXPIRY_MONTH = 3;

    @Value("${apple.url}")
    private String APPLE_URL;

    @Value("${apple.key-path}")
    private String APPLE_KEY_PATH;

    @Value("${apple.client-id}")
    private String APPLE_CLIENT_ID;

    @Value("${apple.team-id}")
    private String APPLE_TEAM_ID;

    @Value("${apple.key-id}")
    private String APPLE_KEY_ID;

    private OAuth2AuthorizationCodeGrantRequestEntityConverter defaultConverter;

    public CustomOAuth2AuthorizationCodeGrantRequestEntityConverter() {
        this.defaultConverter = new OAuth2AuthorizationCodeGrantRequestEntityConverter();
    }

    @Override
    public RequestEntity<?> convert(OAuth2AuthorizationCodeGrantRequest request) {
        RequestEntity<?> requestEntity = defaultConverter.convert(request); //스프링이 기본적으로 제공해주는 converter
        String registrationId = request.getClientRegistration().getRegistrationId();
        Optional<Provider> optionalProvider = Provider.from(registrationId);
        MultiValueMap<String, String> body = (MultiValueMap<String, String>) requestEntity.getBody();
        if (optionalProvider.isPresent() && optionalProvider.get() == Provider.APPLE) {
            body.set(OAuth2ParameterNames.CLIENT_SECRET, createClientSecret()); //애플인 경우에만 client-secret 값 재설정
        }
        return new RequestEntity<>(body, requestEntity.getHeaders(), requestEntity.getMethod(), requestEntity.getUrl());
    }

    //참고: https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret
    //애플이 하라는 대로 client-sercret 생성
    public String createClientSecret() {
        Instant now = Instant.now();
        Date issuedAt = Date.from(now);
        Date expiration = Date.from(now.atZone(ZoneOffset.UTC).plusMonths(CLIENT_SECRET_EXPIRY_MONTH).toInstant());
        Map<String, Object> header = new HashMap<>();
        header.put(DefaultJwsHeader.ALGORITHM, JwsAlgorithms.ES256);
        header.put(DefaultJwsHeader.KEY_ID, APPLE_KEY_ID);

        return Jwts.builder()
                .setHeaderParams(header)
                .setIssuer(APPLE_TEAM_ID)
                .setIssuedAt(issuedAt)
                .setExpiration(expiration)
                .setAudience(APPLE_URL)
                .setSubject(APPLE_CLIENT_ID)
                .signWith(getPrivateKey())
                .compact();
    }

    //PEM 파일을 읽어 Private Key 생성
    public PrivateKey getPrivateKey() {
        ClassPathResource resource = new ClassPathResource(APPLE_KEY_PATH);
        try (InputStream inputStream = resource.getInputStream();
            PEMParser pemParser = new PEMParser(new StringReader(IOUtils.toString(inputStream, StandardCharsets.UTF_8)))) {
            PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(pemParser.readObject());
            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
            return converter.getPrivateKey(privateKeyInfo);
        } catch (IOException e) {
            log.error("Apple Key Parsing Error", e);
            throw new RuntimeException(e);
        }
    }
}
```

- AT, RT 발급 후 (여기서 추가로 애플은 Id Token 이라는 것을 줌) 유저 정보 조회를 위해 `OAuth2UserServiceImpl` 클래스의 `loadUser` 메소드 호출 → 애플은 별도의 유저 정보 조회해오는 API 존재하지 않음 

⁉️ JWT 형식의 Id Token을 디코딩하여 payload의 유저 정보를 가져와야함 + 애플은 이 Id Token의 유효성을 검증할 것을 권장하는데 이 JWT 토큰을 검증하기 위해서는 키가 필요함 → 이 키를 조회해 오는 API가 또 따로 있음

**디코딩된 Id Token Payload 예시**
```json
{
  "iss": "https://appleid.apple.com",
  "aud": "${APPLE_CLIENT_ID}",
  "exp": 1718729646,
  "iat": 1718643246,
  "sub": "123456.a1d12c12ec12345c1bf1234cdb1234bc.1234",
  "at_hash": "asdf-asdfer_m1Pjkluio",
  "email": "dana.kim1999@icloud.com",
  "email_verified": true,
  "auth_time": 1718643245,
  "nonce_supported": true
}
```

```java
@Transactional(readOnly = true)
@RequiredArgsConstructor
@Service
public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {

    private final UserService userService;
    private final OAuth2UserInfoService oAuth2UserInfoService;
    private final AuthSocialLoginRepository authSocialLoginRepository;

    @Transactional
    @Override
    public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
        String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
        String nameAttributeKey = oAuth2UserRequest.getClientRegistration().getProviderDetails()
            .getUserInfoEndpoint().getUserNameAttributeName();
        Map<String, Object> attributes = oAuth2UserInfoService.getAttributes(oAuth2UserRequest, super::loadUser); //유저 정보를 Map 타입으로 조회(내부적으로 소셜 로그인 타입에 따라 분기 처리)

        OAuth2Attributes oAuth2Attributes = OAuth2AttributesFactory.valueOf(registrationId, nameAttributeKey, attributes);
        User user = getSocialLoginedUser(oAuth2Attributes);
        return new OAuth2UserImpl(attributes, nameAttributeKey, user);
    }
}
```

**네이버, 카카오, 구글, 애플 별로 유저 정보 조회해오는 방식이 다 다름**
```java
@RequiredArgsConstructor
@Service
public class OAuth2UserInfoService {

    private final NaverOAuth2UserAttributesServiceImpl naverOAuth2UserAttributesService;
    private final KakaoOAuth2UserAttributesServiceImpl kakaoOAuth2UserAttributesService;
    private final GoogleOAuth2UserAttributesServiceImpl googleOAuth2UserAttributesService;
    private final AppleOAuth2UserAttributesServiceImpl appleOAuth2UserAttributesService;

    public final Map<String, Object> getAttributes(OAuth2UserRequest oAuth2UserRequest,
                                                Function<OAuth2UserRequest, OAuth2User> defaultOAuth2UserFunction) {
        String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
        Provider provider = Provider.from(registrationId)
                .orElseThrow(() -> new BusinessException(NOT_SUPPORTED_SNS_TYPE));
        Map<String, Object> attributes = getDefaultAttributes(provider, defaultOAuth2UserFunction, oAuth2UserRequest);
        switch (provider) {
            case NAVER -> {
                return naverOAuth2UserAttributesService.getAttributes(oAuth2UserRequest, attributes);
            }
            case KAKAO -> {
                return kakaoOAuth2UserAttributesService.getAttributes(oAuth2UserRequest, attributes);
            }
            case GOOGLE -> {
                return googleOAuth2UserAttributesService.getAttributes(oAuth2UserRequest, attributes);
            }
            case APPLE -> {
                return appleOAuth2UserAttributesService.getAttributes(oAuth2UserRequest, attributes);
            }
            default -> throw new BusinessException(NOT_SUPPORTED_SNS_TYPE);
        }
    }

    private Map<String, Object> getDefaultAttributes(Provider provider,
                                                    Function<OAuth2UserRequest, OAuth2User> defaultOAuth2UserFunction,
                                                    OAuth2UserRequest oAuth2UserRequest) {
        if (provider == Provider.APPLE) return new HashMap<>(); //애플은 그런 것 없으므로 빈 HashMap 객체 반환
        return defaultOAuth2UserFunction.apply(oAuth2UserRequest).getAttributes(); //파라미터로 전달된 Function은 DefaultOAuth2UserService(스프링이 기본적으로 제공하는 유저 정보 조회 서비스)의 loadUser 메소드로 각각 적절한 유저 정보 조회 API 호출
    }
}
```

- **네이버, 카카오**: `DefaultOAuth2UserService`로 유저의 필요한 모든 정보 조회 가능 → `NaverOAuth2UserAttributesServiceImpl`, `KakaoOAuth2UserAttributesServiceImpl` 객체 내에서 별도의 동작X 
- **구글**: `DefaultOAuth2UserService`로 유저의 일부 정보 조회 가능(이름, 이메일 등) → 추가 정보(생년월일, 성별 등) 얻기 위해 `GoogleOAuth2UserAttributesServiceImpl`에서 별도의 People API 호출 
- **애플**: 별도의 유저 정보 조회 API 제공X → `AppleOAuth2UserAttributesServiceImpl`에서 id 토큰 검증 후 토큰 디코딩하여 유저 정보 조회

```java
@Slf4j
@RequiredArgsConstructor
@Service
public class AppleOAuth2UserAttributesServiceImpl implements OAuth2UserAttributesService {

    private final AppleIdTokenValidator appleIdTokenValidator;
    private final JwtService jwtService;

    @Override
    public Map<String, Object> getAttributes(OAuth2UserRequest oAuth2UserRequest, Map<String, Object> attributes) {
        String idToken = oAuth2UserRequest.getAdditionalParameters().get(ID_TOKEN).toString();
        appleIdTokenValidator.validate(idToken); //id 토큰 검증

        Map<String, Object> decodedPayload = jwtService.decodePayload(idToken);
        attributes.putAll(decodedPayload); //유저 정보 조회
        return attributes;
    }
}
```

```java
@RequiredArgsConstructor
@Component
public class AppleIdTokenValidator {

    public static final String NONCE_SUPPORTED_CLAIM_KEY = "nonce_supported";
    private final ApplePublicKeyClient applePublicKeyClient;
    private final ApplePublicKeyGenerator applePublicKeyGenerator;
    private final JwtService jwtService;

    @Value("${apple.url}")
    private String APPLE_URL;

    @Value("${apple.client-id}")
    private String APPLE_CLIENT_ID;

    //참고: https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user/
    //위글에서 애플이 하라는대로 토큰 검증
    public void validate(String idToken) {
        Map<String, Object> decodedHeader = jwtService.decodeHeader(idToken);
        DefaultJwsHeader jwtHeader = new DefaultJwsHeader(decodedHeader);
        PublicKey publicKey = getApplePublicKey(decodedHeader);

        //Verify the JWS E256 signature using the server’s public key
        //Verify that the time is earlier than the exp value of the token
        jwtService.validateTokenExpiry(idToken, publicKey);
        Claims claims = jwtService.parseToken(idToken, publicKey);

        //Verify the nonce for the authentication → "nonce_supported": true
        Boolean nonceSupported = claims.get(NONCE_SUPPORTED_CLAIM_KEY, Boolean.class);
        if (!nonceSupported) {
            throw new IncorrectClaimException(jwtHeader, claims,
                    "Invalid Apple Id Token: nonce_supported = " + nonceSupported);
        }

        //Verify that the iss field contains https://appleid.apple.com → "iss": "https://appleid.apple.com"
        String issuer = claims.getIssuer();
        if (!issuer.equals(APPLE_URL)) {
            throw new IncorrectClaimException(jwtHeader, claims, "Invalid Apple Id Token: issuer = " + issuer);
        }

        //Verify that the aud field is the developer’s client_id → "aud": ${APPLE_CLIENT_ID}
        String audience = claims.getAudience();
        if (!audience.equals(APPLE_CLIENT_ID)) {
            throw new IncorrectClaimException(jwtHeader, claims, "Invalid Apple Id Token: audience = " + audience);
        }
    }

    //참고: https://developer.apple.com/documentation/sign_in_with_apple/fetch_apple_s_public_key_for_verifying_token_signature
    private PublicKey getApplePublicKey(Map<String, Object> headers) {
        ApplePublicKeyListResponse applePublicKeyListResponse = applePublicKeyClient.getApplePublicKeyList(); //apple public key 조회하는 API 호출
        return applePublicKeyGenerator.generatePublicKey(headers, applePublicKeyListResponse); //public key 응답값으로 토큰 검증에 필요한 PublicKey 객체 생성
    }
}
```

- 이후 과정은 다른 소셜 로그인과 동일

## 🛠️ 개발 오류 사항

- 따로 유저 정보 조회 API를 제공하지 않기도 하고 유저 이름의 경우 처음 로그인 시 딱 한번만 Auth Code 발급 시(`OAuth2LoginAuthenticationFilter`로 redirect될 때) 이름 정보를 전달해줍니다. Spring OAuth2를 이용해 구현하려다 보니 유저 이름 정보 저장 타이밍이 애매해 애플 로그인 시에는 `user_privacy` 테이블의 `name` 컬럼에 빈 문자열이 들어갑니다. 일단 현재 서비스 로직상 `user_privacy` 테이블 데이터를 사용할 일은 없어 애플 로그인 사용자의 이름을 저장하는 로직은 구현하지 않았습니다. 좋은 아이디어 있다면 알려주세요.

```java
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class AppleOAuth2Attributes extends OAuth2Attributes {

    private static final String ID_KEY = "sub";
    private static final String EMAIL_VERIFIED_KEY = "email_verified";
    private static final String EMAIL_KEY = "email";

    public static OAuth2Attributes of(String nameAttributesKey, Map<String, Object> attributes) {
        return GoogleOAuth2Attributes.builder()
                .id(parseId(attributes))
                .name("") //빈문자열
                .email(parseEmail(attributes))
                .isVerifiedEmail(parseIsVerifiedEmail(attributes))
                .gender(Gender.UNKNOWN) //알 수 없음 기본값
                .ageRange("") //빈문자열
                .birth(LocalDate.now()) //현재 날짜 기본값
                .provider(Provider.APPLE)
                .build(); //이름, 성별, 나이대, 생년월일 정보를 애플로부터 가져올 수 없기 때문에 위와 같이 기본값 설정
    }

    private static String parseId(Map<String, Object> attributes) {
        return String.valueOf(attributes.get(ID_KEY));
    }

    private static String parseEmail(Map<String, Object> attributes) {
        return String.valueOf(attributes.get(EMAIL_KEY));
    }

    private static Boolean parseIsVerifiedEmail(Map<String, Object> attributes) {
        return (boolean) attributes.get(EMAIL_VERIFIED_KEY);
    }
}
```

## 🗣️ For 리뷰어

### 애플 로그인 테스트 방법 
- 환경 변수가 많이 추가되었습니다. 노션 확인해주세요.
- `AuthKey_*.p8` 키 파일이 필요합니다. 이것도 노션에 있고 gitignore에 파일 경로 추가해두었습니다. 꼭 지정한 경로에 파일 위치시켜 주시고, 절대!!! git에 올라가지 않도록 주의해주세요.
- 애플의 경우 redirect uri 설정 시 localhost 및 http 프로토콜을 지정할 수 없습니다. 따라서 ngrok 이라는 툴을 이용해 https 프로토콜로 외부 호스팅?을 해주어야 하는데 다음 글 [참고](https://tlog.tammolo.com/posts/ngrok-localtunnel)하여 설정해주세요. (별로 어렵지 않아요!)
- Apple Developer Redirect URL 설정 방법
  - ngrok으로 호스팅된 url을 apple developer 에서 설정해주어야 하는데, 아이디랑 비밀번호는 세진님께 전달받아 로그인해주세요.
  - 인증서, ID 및 프로파일(Certificates, Identifiers & Profiles) > Identifiers > Services IDs > ForA Apple Login 클릭 > Edit your Services ID Configuration 메뉴에서 configure 버튼 클릭 > Website URLs 메뉴에서 Domains and Subdomains(`1234-123-123-123-123.ngrok-free.app`) + Return URLs(`https://1234-123-123-123-123.ngrok-free.app/login/oauth2/code/apple`) 같은 형태로 추가 > Done > Continue > Save (복잡하면 그냥 저한테 ngrok URL 전달해주세요 제가 설정할께요)
  - 이후 `https://1234-123-123-123-123.ngrok-free.app/oauth2/authorization/apple` 형태로 애플 로그인 요청 → ForA 앱의 JWT 토큰 발급 

- 소셜 로그인 모두 구현 완료되었습니다! 제 로컬에서 모두 테스트해보긴 했는데 네이버, 카카오, 구글, 애플 모두 정상적으로 로그인 및 회원가입 되는지 한번 확인해주세요.

### 참고 
- https://velog.io/@komment/Spring-Boot-OAuth-2.0-JWT%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84-2-%EC%95%A0%ED%94%8C%ED%8E%B8
- https://mingg123.tistory.com/262#google_vignette
- https://green1229.tistory.com/237
- https://velog.io/@ncookie/IMAD-%EC%95%A0%ED%94%8C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84#apiresponsejava
- https://imweb.me/faq?mode=view&category=29&category2=47&idx=71719
- https://www.baeldung.com/java-read-pem-file-keys

close #35