### PR TITLE
병원 운영 상태 조회를 위한 구글 맵 API 연동

### DIFF
--- a/src/main/java/com/project/foradhd/domain/hospital/business/dto/out/HospitalOperationDetailsData.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/dto/out/HospitalOperationDetailsData.java
@@ -12,9 +12,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class HospitalOperationDetailsData {
 
-    private HospitalOperationStatus operationStatus;
-    private Integer operationStartHour;
-    private Integer operationStartMin;
-    private Integer operationEndHour;
-    private Integer operationEndMin;
+    private HospitalOperationStatus operationStatus = HospitalOperationStatus.UNKNOWN;
+    private int operationStartHour;
+    private int operationStartMin;
+    private int operationEndHour;
+    private int operationEndMin;
 }

--- a/src/main/java/com/project/foradhd/domain/hospital/business/dto/out/HospitalOperationDetailsData.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/dto/out/HospitalOperationDetailsData.java
@@ -1,0 +1,20 @@
+package com.project.foradhd.domain.hospital.business.dto.out;
+
+import com.project.foradhd.domain.hospital.web.enums.HospitalOperationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HospitalOperationDetailsData {
+
+    private HospitalOperationStatus operationStatus;
+    private Integer operationStartHour;
+    private Integer operationStartMin;
+    private Integer operationEndHour;
+    private Integer operationEndMin;
+}

--- a/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
@@ -4,12 +4,18 @@ import com.project.foradhd.domain.hospital.business.dto.out.HospitalOperationDet
 import com.project.foradhd.domain.hospital.web.enums.HospitalOperationStatus;
 import com.project.foradhd.global.client.GooglePlacesClient;
 import com.project.foradhd.global.client.dto.response.GooglePlaceOpeningHoursResponse;
+import com.project.foradhd.global.enums.RedisKeyType;
+import com.project.foradhd.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -17,20 +23,33 @@ import java.util.stream.Collectors;
 public class HospitalOperationService {
 
     private final GooglePlacesClient googlePlacesClient;
+    private final RedisService redisService;
 
     public Map<String, HospitalOperationStatus> getHospitalOperationStatus(Map<String, String> placeIdByHospital) {
         return placeIdByHospital.keySet().stream()
                 .collect(Collectors.toMap(hospitalId -> hospitalId, hospitalId -> {
                     String placeId = placeIdByHospital.get(hospitalId);
-                    return googlePlacesClient.getPlaceOpeningHours(placeId)
-                            .filter(response -> response.getCurrentOpeningHours() != null)
-                            .map(this::getOpenNow)
-                            .map(HospitalOperationStatus::from)
-                            .orElse(HospitalOperationStatus.UNKNOWN);
+                    return readHospitalOperationDetails(placeId)
+                            .map(HospitalOperationDetailsData::getOperationStatus)
+                            .orElseGet(() -> {
+                                HospitalOperationDetailsData hospitalOperationDetails = requestHospitalOperationDetails(placeId);
+                                writeHospitalOperationDetails(hospitalOperationDetails, placeId);
+                                return hospitalOperationDetails.getOperationStatus();
+                            });
                 }));
     }
 
     public HospitalOperationDetailsData getHospitalOperationDetails(String placeId) {
+        if (!StringUtils.hasText(placeId)) return new HospitalOperationDetailsData();
+        return readHospitalOperationDetails(placeId)
+                .orElseGet(() -> {
+                    HospitalOperationDetailsData hospitalOperationDetails = requestHospitalOperationDetails(placeId);
+                    writeHospitalOperationDetails(hospitalOperationDetails, placeId);
+                    return hospitalOperationDetails;
+                });
+    }
+
+    private HospitalOperationDetailsData requestHospitalOperationDetails(String placeId) {
         Optional<GooglePlaceOpeningHoursResponse> googlePlaceOpeningHoursResponseOptional =
                 googlePlacesClient.getPlaceOpeningHours(placeId);
 
@@ -50,6 +69,28 @@ public class HospitalOperationService {
                 .operationEndHour(todayOpeningPeriod.getClose().getHour())
                 .operationEndMin(todayOpeningPeriod.getClose().getMinute())
                 .build();
+    }
+
+    private Optional<HospitalOperationDetailsData> readHospitalOperationDetails(String placeId) {
+        return redisService.getValue(RedisKeyType.HOSPITAL_OPERATION_DETAILS, placeId, HospitalOperationDetailsData.class);
+    }
+
+    private void writeHospitalOperationDetails(HospitalOperationDetailsData hospitalOperationDetails, String placeId) {
+        long timeout = calculateTimeout(hospitalOperationDetails);
+        redisService.setValue(RedisKeyType.HOSPITAL_OPERATION_DETAILS, placeId, hospitalOperationDetails, timeout, TimeUnit.SECONDS);
+    }
+
+    private long calculateTimeout(HospitalOperationDetailsData hospitalOperationDetails) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime operationStartTime = now.withHour(hospitalOperationDetails.getOperationStartHour())
+                .withMinute(hospitalOperationDetails.getOperationStartMin())
+                .withSecond(0);
+        LocalDateTime operationEndTime = now.withHour(hospitalOperationDetails.getOperationEndHour())
+                .withMinute(hospitalOperationDetails.getOperationEndMin())
+                .withSecond(0);
+        if (now.isBefore(operationStartTime)) return Duration.between(now, operationStartTime).getSeconds();
+        else if (now.isBefore(operationEndTime)) return Duration.between(now, operationEndTime).getSeconds();
+        return Duration.between(now, operationStartTime.plusDays(1)).getSeconds();
     }
 
     private GooglePlaceOpeningHoursResponse.Period getTodayOpeningPeriod(GooglePlaceOpeningHoursResponse response) {

--- a/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
@@ -90,7 +90,7 @@ public class HospitalOperationService {
                 .withSecond(0);
         if (now.isBefore(operationStartTime)) return Duration.between(now, operationStartTime).getSeconds();
         else if (now.isBefore(operationEndTime)) return Duration.between(now, operationEndTime).getSeconds();
-        return Duration.between(now, operationStartTime.plusDays(1)).getSeconds();
+        return Duration.between(now, now.plusDays(1).toLocalDate().atStartOfDay()).getSeconds();
     }
 
     private GooglePlaceOpeningHoursResponse.Period getTodayOpeningPeriod(GooglePlaceOpeningHoursResponse response) {

--- a/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
@@ -1,0 +1,48 @@
+package com.project.foradhd.domain.hospital.business.service;
+
+import com.project.foradhd.domain.hospital.web.enums.HospitalOperationStatus;
+import com.project.foradhd.global.client.GooglePlacesClient;
+import com.project.foradhd.global.client.dto.response.GooglePlaceOpeningHoursResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class HospitalOperationService {
+
+    private final GooglePlacesClient googlePlacesClient;
+
+    public Map<String, HospitalOperationStatus> getHospitalOperationStatus(Map<String, String> placeIdByHospital) {
+        return placeIdByHospital.keySet().stream()
+                .collect(Collectors.toMap(hospitalId -> hospitalId, hospitalId -> {
+                    String placeId = placeIdByHospital.get(hospitalId);
+                    GooglePlaceOpeningHoursResponse operationDetails = googlePlacesClient.getPlaceOpeningHours(placeId);
+                    return getOpenNow(operationDetails)
+                            .map(HospitalOperationStatus::from)
+                            .orElse(HospitalOperationStatus.UNKNOWN);
+                }));
+    }
+
+    public Optional<Boolean> getOpenNow(GooglePlaceOpeningHoursResponse response) {
+        if (response.getCurrentOpeningHours() == null) return Optional.empty();
+        return Optional.of(response.getCurrentOpeningHours().isOpenNow());
+    }
+
+    public GooglePlaceOpeningHoursResponse.Period getTodayOpeningPeriod(GooglePlaceOpeningHoursResponse response) {
+        LocalDate now = LocalDate.now();
+        return response.getCurrentOpeningHours().getPeriods().stream()
+                .filter(period -> {
+                    GooglePlaceOpeningHoursResponse.Date date = period.getOpen().getDate();
+                    return date.getYear() == now.getYear() &&
+                            date.getMonth() == now.getMonthValue() &&
+                            date.getDay() == now.getDayOfMonth();
+                })
+                .findFirst()
+                .orElse(new GooglePlaceOpeningHoursResponse.Period());
+    }
+}

--- a/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalOperationService.java
@@ -1,5 +1,6 @@
 package com.project.foradhd.domain.hospital.business.service;
 
+import com.project.foradhd.domain.hospital.business.dto.out.HospitalOperationDetailsData;
 import com.project.foradhd.domain.hospital.web.enums.HospitalOperationStatus;
 import com.project.foradhd.global.client.GooglePlacesClient;
 import com.project.foradhd.global.client.dto.response.GooglePlaceOpeningHoursResponse;
@@ -21,19 +22,30 @@ public class HospitalOperationService {
         return placeIdByHospital.keySet().stream()
                 .collect(Collectors.toMap(hospitalId -> hospitalId, hospitalId -> {
                     String placeId = placeIdByHospital.get(hospitalId);
-                    GooglePlaceOpeningHoursResponse operationDetails = googlePlacesClient.getPlaceOpeningHours(placeId);
-                    return getOpenNow(operationDetails)
+                    GooglePlaceOpeningHoursResponse response = googlePlacesClient.getPlaceOpeningHours(placeId);
+                    return getOpenNow(response)
                             .map(HospitalOperationStatus::from)
                             .orElse(HospitalOperationStatus.UNKNOWN);
                 }));
     }
 
-    public Optional<Boolean> getOpenNow(GooglePlaceOpeningHoursResponse response) {
-        if (response.getCurrentOpeningHours() == null) return Optional.empty();
-        return Optional.of(response.getCurrentOpeningHours().isOpenNow());
+    public HospitalOperationDetailsData getHospitalOperationDetails(String placeId) {
+        GooglePlaceOpeningHoursResponse response = googlePlacesClient.getPlaceOpeningHours(placeId);
+        HospitalOperationStatus operationStatus = getOpenNow(response)
+                .map(HospitalOperationStatus::from)
+                .orElse(HospitalOperationStatus.UNKNOWN);
+        GooglePlaceOpeningHoursResponse.Period todayOpeningPeriod = getTodayOpeningPeriod(response);
+        return HospitalOperationDetailsData.builder()
+                .operationStatus(operationStatus)
+                .operationStartHour(todayOpeningPeriod.getOpen().getHour())
+                .operationStartMin(todayOpeningPeriod.getOpen().getMinute())
+                .operationEndHour(todayOpeningPeriod.getClose().getHour())
+                .operationEndMin(todayOpeningPeriod.getClose().getMinute())
+                .build();
     }
 
-    public GooglePlaceOpeningHoursResponse.Period getTodayOpeningPeriod(GooglePlaceOpeningHoursResponse response) {
+    private GooglePlaceOpeningHoursResponse.Period getTodayOpeningPeriod(GooglePlaceOpeningHoursResponse response) {
+        if (response.getCurrentOpeningHours() == null) return new GooglePlaceOpeningHoursResponse.Period();
         LocalDate now = LocalDate.now();
         return response.getCurrentOpeningHours().getPeriods().stream()
                 .filter(period -> {
@@ -44,5 +56,10 @@ public class HospitalOperationService {
                 })
                 .findFirst()
                 .orElse(new GooglePlaceOpeningHoursResponse.Period());
+    }
+
+    private Optional<Boolean> getOpenNow(GooglePlaceOpeningHoursResponse response) {
+        if (response.getCurrentOpeningHours() == null) return Optional.empty();
+        return Optional.of(response.getCurrentOpeningHours().isOpenNow());
     }
 }

--- a/src/main/java/com/project/foradhd/domain/hospital/persistence/entity/Hospital.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/persistence/entity/Hospital.java
@@ -32,6 +32,8 @@ public class Hospital extends BaseTimeEntity {
     @Column(length = 11)
     private String phone;
 
+    private String placeId;
+
     @Builder.Default
     @ColumnDefault("0")
     @Column(nullable = false)

--- a/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -40,7 +41,7 @@ public class HospitalController {
 
         Map<String, String> placeIdByHospital = hospitalListNearbyData.getHospitalList().stream()
                 .map(HospitalListNearbyData.HospitalNearbyData::getHospital)
-                .filter(hospital -> hospital.getPlaceId() != null)
+                .filter(hospital -> StringUtils.hasText(hospital.getPlaceId()))
                 .collect(Collectors.toMap(Hospital::getId, Hospital::getPlaceId));
         Map<String, HospitalOperationStatus> operationStatusByHospital =
                 hospitalOperationService.getHospitalOperationStatus(placeIdByHospital);
@@ -68,7 +69,7 @@ public class HospitalController {
 
         Map<String, String> placeIdByHospital = hospitalListBookmarkData.getHospitalList().stream()
                 .map(HospitalListBookmarkData.HospitalBookmarkData::getHospital)
-                .filter(hospital -> hospital.getPlaceId() != null)
+                .filter(hospital -> StringUtils.hasText(hospital.getPlaceId()))
                 .collect(Collectors.toMap(Hospital::getId, Hospital::getPlaceId));
         Map<String, HospitalOperationStatus> operationStatusByHospital =
                 hospitalOperationService.getHospitalOperationStatus(placeIdByHospital);

--- a/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
@@ -65,6 +65,15 @@ public class HospitalController {
                                                                                 Pageable pageable) {
         HospitalListBookmarkData hospitalListBookmarkData = hospitalService.getHospitalListBookmark(userId, pageable);
         HospitalListBookmarkResponse hospitalListBookmarkResponse = hospitalMapper.toHospitalListBookmarkResponse(hospitalListBookmarkData);
+
+        Map<String, String> placeIdByHospital = hospitalListBookmarkData.getHospitalList().stream()
+                .map(HospitalListBookmarkData.HospitalBookmarkData::getHospital)
+                .filter(hospital -> hospital.getPlaceId() != null)
+                .collect(Collectors.toMap(Hospital::getId, Hospital::getPlaceId));
+        Map<String, HospitalOperationStatus> operationStatusByHospital =
+                hospitalOperationService.getHospitalOperationStatus(placeIdByHospital);
+        hospitalMapper.synchronizeOperationStatus(hospitalListBookmarkResponse, operationStatusByHospital);
+
         return ResponseEntity.ok(hospitalListBookmarkResponse);
     }
 

--- a/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
@@ -98,6 +98,11 @@ public class HospitalController {
                                                                     @PathVariable String hospitalId) {
         HospitalDetailsData hospitalDetailsData = hospitalService.getHospitalDetails(userId, hospitalId);
         HospitalDetailsResponse hospitalDetailsResponse = hospitalMapper.toHospitalDetailsResponse(hospitalDetailsData);
+
+        String placeId = hospitalDetailsData.getHospital().getPlaceId();
+        HospitalOperationDetailsData hospitalOperationDetails = hospitalOperationService.getHospitalOperationDetails(placeId);
+        hospitalMapper.synchronizeOperationDetails(hospitalDetailsResponse, hospitalOperationDetails);
+
         return ResponseEntity.ok(hospitalDetailsResponse);
     }
 

--- a/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalDetailsResponse.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalDetailsResponse.java
@@ -30,6 +30,15 @@ public class HospitalDetailsResponse {
     private Integer operationEndMin;
     private List<DoctorResponse> doctorList;
 
+    public void synchronizeOperationDetails(HospitalOperationStatus operationStatus, Integer operationStartHour, Integer operationStartMin,
+                                            Integer operationEndHour, Integer operationEndMin) {
+        this.operationStatus = operationStatus;
+        this.operationStartHour = operationStartHour;
+        this.operationStartMin = operationStartMin;
+        this.operationEndHour = operationEndHour;
+        this.operationEndMin = operationEndMin;
+    }
+
     @Getter
     @Builder
     public static class DoctorResponse {

--- a/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalListBookmarkResponse.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalListBookmarkResponse.java
@@ -23,5 +23,9 @@ public class HospitalListBookmarkResponse {
         private Integer totalReceiptReviewCount;
         private Integer totalEvaluationReviewCount;
         private HospitalOperationStatus operationStatus;
+
+        public void synchronizeOperationStatus(HospitalOperationStatus operationStatus) {
+            this.operationStatus = operationStatus;
+        }
     }
 }

--- a/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalListNearbyResponse.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalListNearbyResponse.java
@@ -27,5 +27,9 @@ public class HospitalListNearbyResponse {
         private Double distance;
         private HospitalOperationStatus operationStatus;
         private Boolean isBookmarked;
+
+        public void synchronizeOperationStatus(HospitalOperationStatus operationStatus) {
+            this.operationStatus = operationStatus;
+        }
     }
 }

--- a/src/main/java/com/project/foradhd/domain/hospital/web/enums/HospitalOperationStatus.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/enums/HospitalOperationStatus.java
@@ -2,5 +2,10 @@ package com.project.foradhd.domain.hospital.web.enums;
 
 public enum HospitalOperationStatus {
 
-    OPEN, CLOSED
+    OPEN, CLOSED, UNKNOWN;
+
+    public static HospitalOperationStatus from(boolean openNow) {
+        if (openNow) return OPEN;
+        return CLOSED;
+    }
 }

--- a/src/main/java/com/project/foradhd/domain/hospital/web/mapper/HospitalMapper.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/mapper/HospitalMapper.java
@@ -168,4 +168,14 @@ public interface HospitalMapper {
                     hospital.synchronizeOperationStatus(operationStatus);
                 });
     }
+
+    default void synchronizeOperationStatus(HospitalListBookmarkResponse hospitalListBookmarkResponse,
+                                            Map<String, HospitalOperationStatus> operationStatusByHospital) {
+        hospitalListBookmarkResponse.getHospitalList()
+                .forEach(hospital -> {
+                    String hospitalId = hospital.getHospitalId();
+                    HospitalOperationStatus operationStatus = operationStatusByHospital.getOrDefault(hospitalId, HospitalOperationStatus.UNKNOWN);
+                    hospital.synchronizeOperationStatus(operationStatus);
+                });
+    }
 }

--- a/src/main/java/com/project/foradhd/domain/hospital/web/mapper/HospitalMapper.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/mapper/HospitalMapper.java
@@ -178,4 +178,14 @@ public interface HospitalMapper {
                     hospital.synchronizeOperationStatus(operationStatus);
                 });
     }
+
+    default void synchronizeOperationDetails(HospitalDetailsResponse hospitalDetailsResponse, HospitalOperationDetailsData hospitalOperationDetails) {
+        HospitalOperationStatus operationStatus = hospitalOperationDetails.getOperationStatus();
+        Integer operationStartHour = hospitalOperationDetails.getOperationStartHour();
+        Integer operationStartMin = hospitalOperationDetails.getOperationStartMin();
+        Integer operationEndHour = hospitalOperationDetails.getOperationEndHour();
+        Integer operationEndMin = hospitalOperationDetails.getOperationEndMin();
+        hospitalDetailsResponse.synchronizeOperationDetails(operationStatus, operationStartHour, operationStartMin,
+                operationEndHour, operationEndMin);
+    }
 }

--- a/src/main/java/com/project/foradhd/domain/hospital/web/mapper/HospitalMapper.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/mapper/HospitalMapper.java
@@ -9,10 +9,12 @@ import com.project.foradhd.domain.hospital.persistence.entity.HospitalEvaluation
 import com.project.foradhd.domain.hospital.web.dto.request.*;
 import com.project.foradhd.domain.hospital.web.dto.response.*;
 import com.project.foradhd.domain.hospital.web.dto.response.HospitalListNearbyResponse.HospitalNearbyResponse;
+import com.project.foradhd.domain.hospital.web.enums.HospitalOperationStatus;
 import org.mapstruct.*;
 import org.mapstruct.MappingConstants.ComponentModel;
 
 import java.util.List;
+import java.util.Map;
 
 @Mapper(componentModel = ComponentModel.SPRING)
 public interface HospitalMapper {
@@ -156,4 +158,14 @@ public interface HospitalMapper {
     HospitalEvaluationReviewCreateData toHospitalEvaluationReviewCreateData(HospitalEvaluationReviewCreateRequest request);
 
     HospitalEvaluationReviewUpdateData toHospitalEvaluationReviewUpdateData(HospitalEvaluationReviewUpdateRequest request);
+
+    default void synchronizeOperationStatus(HospitalListNearbyResponse hospitalListNearbyResponse,
+                                            Map<String, HospitalOperationStatus> operationStatusByHospital) {
+        hospitalListNearbyResponse.getHospitalList()
+                .forEach(hospital -> {
+                    String hospitalId = hospital.getHospitalId();
+                    HospitalOperationStatus operationStatus = operationStatusByHospital.getOrDefault(hospitalId, HospitalOperationStatus.UNKNOWN);
+                    hospital.synchronizeOperationStatus(operationStatus);
+                });
+    }
 }

--- a/src/main/java/com/project/foradhd/global/client/GooglePlacesClient.java
+++ b/src/main/java/com/project/foradhd/global/client/GooglePlacesClient.java
@@ -1,0 +1,15 @@
+package com.project.foradhd.global.client;
+
+import com.project.foradhd.global.client.config.GooglePlacesClientConfig;
+import com.project.foradhd.global.client.dto.response.GooglePlaceOpeningHoursResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "googlePlacesClient", url = "${google.places.url}",
+        configuration = GooglePlacesClientConfig.class)
+public interface GooglePlacesClient {
+
+    @GetMapping("/{placeId}")
+    GooglePlaceOpeningHoursResponse getPlaceOpeningHours(@PathVariable String placeId);
+}

--- a/src/main/java/com/project/foradhd/global/client/GooglePlacesClient.java
+++ b/src/main/java/com/project/foradhd/global/client/GooglePlacesClient.java
@@ -6,10 +6,12 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import java.util.Optional;
+
 @FeignClient(name = "googlePlacesClient", url = "${google.places.url}",
         configuration = GooglePlacesClientConfig.class)
 public interface GooglePlacesClient {
 
     @GetMapping("/{placeId}")
-    GooglePlaceOpeningHoursResponse getPlaceOpeningHours(@PathVariable String placeId);
+    Optional<GooglePlaceOpeningHoursResponse> getPlaceOpeningHours(@PathVariable String placeId);
 }

--- a/src/main/java/com/project/foradhd/global/client/config/GooglePlacesClientConfig.java
+++ b/src/main/java/com/project/foradhd/global/client/config/GooglePlacesClientConfig.java
@@ -1,0 +1,25 @@
+package com.project.foradhd.global.client.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GooglePlacesClientConfig {
+
+    private static final String GOOGLE_OPERATION_STATUS_FIELD_MASK_HEADER = "currentOpeningHours";
+    private static final String GOOGLE_LANGUAGE_CODE_PARAM = "ko";
+
+    @Value("${google.places.api-key}")
+    private String apiKey;
+
+    @Bean
+    public RequestInterceptor googlePlacesRequestInterceptor() {
+        return restTemplate -> {
+            restTemplate.header("X-Goog-Api-Key", apiKey);
+            restTemplate.header("X-Goog-FieldMask", GOOGLE_OPERATION_STATUS_FIELD_MASK_HEADER);
+            restTemplate.query("languageCode", GOOGLE_LANGUAGE_CODE_PARAM);
+        };
+    }
+}

--- a/src/main/java/com/project/foradhd/global/client/dto/response/GooglePlaceOpeningHoursResponse.java
+++ b/src/main/java/com/project/foradhd/global/client/dto/response/GooglePlaceOpeningHoursResponse.java
@@ -1,0 +1,41 @@
+package com.project.foradhd.global.client.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GooglePlaceOpeningHoursResponse {
+
+    private CurrentOpeningHours currentOpeningHours;
+
+    @Getter
+    public static class CurrentOpeningHours {
+
+        private boolean openNow;
+        private List<Period> periods;
+    }
+
+    @Getter
+    public static class Period {
+
+        private Time open = new Time();
+        private Time close = new Time();
+    }
+
+    @Getter
+    public static class Time {
+
+        private int day;
+        private int hour;
+        private int minute;
+        private Date date = new Date();
+    }
+
+    @Getter
+    public static class Date {
+        private int year;
+        private int month;
+        private int day;
+    }
+}

--- a/src/main/java/com/project/foradhd/global/config/RedisConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); //TODO: 클래스의 패키지 정보까지 저장 → MSA 환경에서 오류 발생
         return redisTemplate;
     }
 }

--- a/src/main/java/com/project/foradhd/global/enums/RedisKeyType.java
+++ b/src/main/java/com/project/foradhd/global/enums/RedisKeyType.java
@@ -6,17 +6,18 @@ import lombok.RequiredArgsConstructor;
 public enum RedisKeyType {
 
     USER_REFRESH_TOKEN("user", "refresh-token"),
-    USER_EMAIL_AUTH_CODE("user", "email-auth-code");
+    USER_EMAIL_AUTH_CODE("user", "email-auth-code"),
+    HOSPITAL_OPERATION_DETAILS("hospital", "operation-details");
 
     private final String domain;
     private final String dataType;
-    private static final String KEY_SEPERATOR = ":";
+    private static final String KEY_SEPARATOR = ":";
 
     public String getKey(String id) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(domain).append(KEY_SEPERATOR)
-                .append(dataType).append(KEY_SEPERATOR)
-                .append(id);
-        return builder.toString();
+        return new StringBuilder()
+                .append(domain).append(KEY_SEPARATOR)
+                .append(dataType).append(KEY_SEPARATOR)
+                .append(id)
+                .toString();
     }
 }

--- a/src/main/java/com/project/foradhd/global/service/RedisService.java
+++ b/src/main/java/com/project/foradhd/global/service/RedisService.java
@@ -1,6 +1,7 @@
 package com.project.foradhd.global.service;
 
 import com.project.foradhd.global.enums.RedisKeyType;
+import com.project.foradhd.global.util.JsonUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -30,25 +31,30 @@ public class RedisService {
         return getValue(redisKeyType.getKey(id));
     }
 
-    @Transactional
-    public void setValue(String key, String value, long timeout, TimeUnit unit) {
-        ValueOperations<String, Object> operations = redisTemplate.opsForValue();
-        operations.set(key, value, timeout, unit);
+    public <T> Optional<T> getValue(RedisKeyType redisKeyType, String id, Class<T> clazz) {
+        return getValue(redisKeyType, id)
+                .map(obj -> JsonUtil.readValue(obj.toString(), clazz));
     }
 
     @Transactional
-    public void setValue(RedisKeyType redisKeyType, String id, String value, long timeout, TimeUnit unit) {
+    public void setValue(String key, Object value, long timeout, TimeUnit unit) {
+        ValueOperations<String, Object> operations = redisTemplate.opsForValue();
+        operations.set(key, JsonUtil.writeValueAsString(value), timeout, unit);
+    }
+
+    @Transactional
+    public void setValue(RedisKeyType redisKeyType, String id, Object value, long timeout, TimeUnit unit) {
         setValue(redisKeyType.getKey(id), value, timeout, unit);
     }
 
     @Transactional
-    public void setValue(String key, String value, Duration timeout) {
+    public void setValue(String key, Object value, Duration timeout) {
         ValueOperations<String, Object> operations = redisTemplate.opsForValue();
-        operations.set(key, value, timeout);
+        operations.set(key, JsonUtil.writeValueAsString(value), timeout);
     }
 
     @Transactional
-    public void setValue(RedisKeyType redisKeyType, String id, String value, Duration timeout) {
+    public void setValue(RedisKeyType redisKeyType, String id, Object value, Duration timeout) {
         setValue(redisKeyType.getKey(id), value, timeout);
     }
 

--- a/src/main/java/com/project/foradhd/global/service/RedisService.java
+++ b/src/main/java/com/project/foradhd/global/service/RedisService.java
@@ -1,7 +1,6 @@
 package com.project.foradhd.global.service;
 
 import com.project.foradhd.global.enums.RedisKeyType;
-import com.project.foradhd.global.util.JsonUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -33,13 +32,13 @@ public class RedisService {
 
     public <T> Optional<T> getValue(RedisKeyType redisKeyType, String id, Class<T> clazz) {
         return getValue(redisKeyType, id)
-                .map(obj -> JsonUtil.readValue(obj.toString(), clazz));
+                .map(obj -> clazz.isInstance(obj) ? clazz.cast(obj) : null);
     }
 
     @Transactional
     public void setValue(String key, Object value, long timeout, TimeUnit unit) {
         ValueOperations<String, Object> operations = redisTemplate.opsForValue();
-        operations.set(key, JsonUtil.writeValueAsString(value), timeout, unit);
+        operations.set(key, value, timeout, unit);
     }
 
     @Transactional
@@ -50,7 +49,7 @@ public class RedisService {
     @Transactional
     public void setValue(String key, Object value, Duration timeout) {
         ValueOperations<String, Object> operations = redisTemplate.opsForValue();
-        operations.set(key, JsonUtil.writeValueAsString(value), timeout);
+        operations.set(key, value, timeout);
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,11 @@ cloud:
     cloud-front:
       deploy-domain: ${CLOUD_FRONT_DEPLOY_DOMAIN}
 
+google:
+  places:
+    api-key: ${GOOGLE_PLACES_API_KEY}
+    url: ${GOOGLE_PLACES_URL}
+
 ---
 spring:
   config:
@@ -71,11 +76,6 @@ logging:
     org.hibernate.sql: info
     org.hibernate.type.descriptor.sql: trace
     com.project.foradhd: debug
-
-google:
-  places:
-    api-key: ${GOOGLE_PLACES_API_KEY}
-    url: ${GOOGLE_PLACES_URL}
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,11 @@ logging:
     org.hibernate.type.descriptor.sql: trace
     com.project.foradhd: debug
 
+google:
+  places:
+    api-key: ${GOOGLE_PLACES_API_KEY}
+    url: ${GOOGLE_PLACES_URL}
+
 ---
 spring:
   config:


### PR DESCRIPTION
## 💻 구현 내용 

- 병원 운영 상태(OPEN/CLOSED, 운영 시작/종료 시간) 조회 위한 구글 맵 API 연동
- ForA 서버에 대한 API 요청 시 내부적으로 Google Places API 호출하여 응답에 포함
   - 내 주변 병원 목록 조회
   - 내가 저장한 병원 목록 조회
   - 병원 상세 조회
- API 요청 당 비용이 청구되므로 내부적으로 요청한 Places API 응답값 캐싱 -> 병원 운영 시작/종료 시간 기준으로 timeout 설정하여 레디스에 저장
  ```java
  private void writeHospitalOperationDetails(HospitalOperationDetailsData hospitalOperationDetails, String placeId) {
      long timeout = calculateTimeout(hospitalOperationDetails);
      redisService.setValue(RedisKeyType.HOSPITAL_OPERATION_DETAILS, placeId, hospitalOperationDetails, timeout, TimeUnit.SECONDS);
  }

  private long calculateTimeout(HospitalOperationDetailsData hospitalOperationDetails) {
      LocalDateTime now = LocalDateTime.now();
      LocalDateTime operationStartTime = now.withHour(hospitalOperationDetails.getOperationStartHour())
              .withMinute(hospitalOperationDetails.getOperationStartMin())
              .withSecond(0);
      LocalDateTime operationEndTime = now.withHour(hospitalOperationDetails.getOperationEndHour())
              .withMinute(hospitalOperationDetails.getOperationEndMin())
              .withSecond(0);
      if (now.isBefore(operationStartTime)) return Duration.between(now, operationStartTime).getSeconds(); //현재 ~ 운영 시작 시각 동안 캐싱
      else if (now.isBefore(operationEndTime)) return Duration.between(now, operationEndTime).getSeconds(); //현재 ~ 운영 종료 시각 동안 캐싱
      return Duration.between(now, now.plusDays(1).toLocalDate().atStartOfDay()).getSeconds(); //운영 종료 시각 후에는 다음날 0시까지 캐싱
  }
  ```

## 🛠️ 개발 오류 사항

- 네이버, 카카오 지도 api에서는 해당 정보 제공하지 않음. 관련 문의와 답변
  - 네이버: https://developers.naver.com/forum/posts/26126
  - 카카오: https://devtalk.kakao.com/t/kakao-map-api/131821
- 구글 맵 API에서는 제한적으로 제공
  - 관련 문서: https://developers.google.com/maps/documentation/places/web-service/place-details?hl=ko&_gl=1*knp2ny*_up*MQ..*_ga*MzgwNzgxMzE4LjE3MTc0MjQ5MjY.*_ga_NRWSTWS78N*MTcxNzQyNDkyNi4xLjAuMTcxNzQyNjg1MC4wLjAuMA..

- 레디스 클래스 -> 문자열 Serializer 
  - 이전에는 key-value에서 value의 serizlizer로 `StringRedisSerializer`를 사용했습니다. 지금까지는 value로 단순 문자열만을 저장해옴. 
  - 이번 처음으로 객체를 레디스에 저장하게 되었는데 `HospitalOperationDetailsData cannot be cast to class java.lang.String` 이러한 오류가 발생했습니다. 객체를 문자열로 캐스팅할 수 없다는 것인데 이를 위해 Jackson 라이브러리에서 제공하는 serializer를 설정해줘야 했습니다. 
  - `GenericJackson2JsonRedisSerializer`를 일단 지정하였으나 다음과 같은 문제가 있습니다. `"{\"@class\":\"com.project.foradhd.domain.hospital.business.dto.out.HospitalOperationDetailsData\",\"operationStatus\":\"CLOSED\",\"operationStartHour\":0,\"operationStartMin\":0,\"operationEndHour\":0,\"operationEndMin\":0}"`
    위와 같이 클래스의 패키지 정보까지 같이 저장되어 MSA 환경의 서로 다른 프로젝트에서 레디스에 저장된 값을 조회 시 역직렬화 오류가 발생할 수 있습니다. 일단 저희가 MSA 환경은 아니기 때문에 `GenericJackson2JsonRedisSerializer`로 설정하였으나 추후 커스텀 Serializer 등으로의 변경이 필요합니다. [참고](https://velog.io/@bagt/Redis-%EC%97%AD%EC%A7%81%EB%A0%AC%ED%99%94-%EC%82%BD%EC%A7%88%EA%B8%B0-feat.-RedisSerializer#-1-jackson2jsonredisserializer)

## 🗣️ For 리뷰어

- 병원 운영 정보 캐싱을 위해 위와 같이 병원 운영 시작/종료 시간 기준으로 timeout을 설정했는데 더 좋은 방법이 있다면 공유해주세요!
- 구글 맵 API 호출을 위해서는 병원 별로 `placeId` 라는 것이 필요합니다. 저희 포스트맨의 **텍스트 검색 (신규)** api 응답 값 중 `places[].id` 가 해당 값을 의미하는데, 병원 1724개를 일일이 설정해줄 수 없어서 앞서 날렸던 병원 CSV 관련 PR에서 `placeId`가 DB에 자동 설정되도록 수정할 예정입니다. 

close #49