### PR TITLE
소셜 로그인 키 관리 방식 변경

### DIFF
--- a/src/main/java/com/project/foradhd/global/client/config/GooglePlacesClientConfig.java
+++ b/src/main/java/com/project/foradhd/global/client/config/GooglePlacesClientConfig.java
@@ -3,11 +3,9 @@ package com.project.foradhd.global.client.config;
 import feign.RequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 
-@Configuration
 public class GooglePlacesClientConfig {
 
     private static final String HEADER_SEPARATOR = ",";

--- a/src/main/java/com/project/foradhd/global/client/config/GooglePlacesClientConfig.java
+++ b/src/main/java/com/project/foradhd/global/client/config/GooglePlacesClientConfig.java
@@ -16,7 +16,7 @@ public class GooglePlacesClientConfig {
     private static final String GOOGLE_LANGUAGE_CODE_PARAM = "ko";
     private static final String PLACES_SEARCH_PATH = "searchText";
 
-    @Value("${google.places.api-key}")
+    @Value("${google.api-key}")
     private String apiKey;
 
     @Bean

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -4,8 +4,8 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ENC(9Z6DKoVAi506YeSk/5sn+HjZ4zTtvbSciOFtWlKXSk1mmkvRZolPniTRNbGgDLz9)
-            client-secret: ENC(BBNo5ldktHfZhnmLejtKHCGjGWLHFu9iD7doNKrWz/2MNYjuNxFQe+9AB+FqA2XL)
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
@@ -18,8 +18,8 @@ spring:
               - age_range
               - gender
           naver:
-            client-id: ENC(FGYIfJlxdtT4NyOxnV80uuttXOM8NI1FUcsBqSyUmtk=)
-            client-secret: ENC(9y68M+H96/5a0h6oX1zgAKCC27yBO5ll)
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             redirect-uri: ${NAVER_REDIRECT_URI}
             authorization-grant-type: authorization_code
@@ -32,8 +32,8 @@ spring:
               - age
               - gender
           google:
-            client-id: ENC(xFTwpvTGxef+wwSfLB8qByEeI2TYMcU3iL29iKCBWBOB8f4ZIx8+c52XhlOeykD0d9MxI3ImOu5Rm39LUEORl/7eMfO6W/xXxuhHKwl2eJjQlUmcy0LNSg==)
-            client-secret: ENC(FsYy9X+Zw3EEL69+6b2q1tm+DBsZA2fbKWh2MCKM8PWPqD7Ri1rC7hyxGeZCuH+D)
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: ${GOOGLE_REDIRECT_URI}
             scope:
               - email
@@ -42,7 +42,7 @@ spring:
               - https://www.googleapis.com/auth/profile.agerange.read
               - https://www.googleapis.com/auth/user.gender.read
           apple:
-            client-id: ENC(VS8LFA0hL4ni+mPBHg78TtsQF4B6wB62JEbo7NMT3k8=)
+            client-id: ${APPLE_CLIENT_ID}
             client-authentication-method: client_secret_post
             redirect-uri: ${APPLE_REDIRECT_URI}
             authorization-grant-type: authorization_code

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,8 +51,8 @@ service:
     key: ${MEDICINE_SERVICE_KEY}
 
 google:
+  api-key: ${GOOGLE_API_KEY}
   places:
-    api-key: ${GOOGLE_PLACES_API_KEY}
     url: ${GOOGLE_PLACES_URL}
 
 ---


### PR DESCRIPTION
## 💻 구현 내용 

- 해당 PR 별건 없고 카카오, 네이버, 구글, 애플의 client id, client secret 키 주입 방식이 기존에는 jasypt 라이브러리로 암호화된 문자열을 코드에 삽입하는 방식이었습니다. 이 경우 해당 값들이 변경될 때마다 매번 재컴파일해야 하는 불편함이 있어 이 또한 환경 변수로 주입해주도록 설정 변경하였습니다. 
- 기존에는 jasypt 암호화 방식을 단순히 사용해보고 싶어 이렇게 구현했던 건데 생각치 못한 불편함이 있어 변경하게 되었습니다. 
- 해당 PR에서 변경되는, 추가되는 환경변수는 다음과 같습니다. ('환경변수 및 secret key 공유' 문서에서 확인해주세요)
  ```text
  GOOGLE_API_KEY => 변수명 및 값 변경

  KAKAO_CLIENT_ID
  KAKAO_CLIENT_SECRET
  NAVER_CLIENT_ID
  NAVER_CLIENT_SECRET
  GOOGLE_CLIENT_ID
  GOOGLE_CLIENT_SECRET
  => 변수 추가
  ```

## 🛠️ 개발 오류 사항

- 구글 Places API Client에 적용했던 관련 설정 클래스 `GooglePlacesClientConfig`가 구글 로그인 시 호출되는 `GoogleOAuth2PeopleApiClient`에도 적용되어 오류가 발생 -> `GooglePlacesClientConfig`에 포함된 `@Configuration` 어노테이션 제거하여 전역 빈으로 등록되는 `RequestInterceptor`가 특정 feign client(`@FeignClient` 어노테이션의 `configuration` 속성으로 설정한 경우에만)에만 적용되도록 설정

- 소셜 로그인을 운영 환경으로 전환하기 위해, 앱 스토어 배포 여부를 확인하는 경우도 존재합니다. 따라서 몇몇 소셜 로그인은 앱 배포가 완료된 후에야 운영 환경으로 전환될 수 있습니다. (심사 3~5일? 소요)

close #55