### PR TITLE
유저 이메일 중복 여부 확인 api 개발

### DIFF
--- a/src/main/java/com/project/foradhd/domain/user/business/dto/out/UserTokenData.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/dto/out/UserTokenData.java
@@ -2,8 +2,10 @@ package com.project.foradhd.domain.user.business.dto.out;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class UserTokenData {
 

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserEmailAuthService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserEmailAuthService.java
@@ -4,9 +4,11 @@ import com.project.foradhd.domain.user.business.dto.in.EmailAuthData;
 import com.project.foradhd.domain.user.business.dto.in.EmailAuthValidationData;
 import com.project.foradhd.domain.user.persistence.entity.User;
 
+import java.util.Optional;
+
 public interface UserEmailAuthService {
 
     void authenticateEmail(String userId, EmailAuthData emailAuthData);
 
-    User validateEmailAuth(String userId, EmailAuthValidationData emailAuthValidationData);
+    Optional<User> validateEmailAuth(String userId, EmailAuthValidationData emailAuthValidationData);
 }

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
@@ -21,6 +21,8 @@ public interface UserService {
 
     boolean checkNickname(String nickname);
 
+    boolean checkEmail(String email);
+
     UserProfileDetailsData getUserProfileDetails(String userId);
 
     User signUp(SignUpData signUpData);

--- a/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
@@ -39,6 +39,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public boolean checkEmail(String email) {
+        return userRepository.findByEmail(email).isEmpty();
+    }
+
+    @Override
     public UserProfileDetailsData getUserProfileDetails(String userId) {
         UserProfile userProfile = getUserProfileFetch(userId);
         return UserProfileDetailsData.builder()

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -39,6 +39,12 @@ public class UserController {
         return ResponseEntity.ok(new NicknameCheckResponse(isValidNickname));
     }
 
+    @GetMapping("/email-check")
+    public ResponseEntity<EmailCheckResponse> checkEmail(@RequestBody @Valid EmailCheckRequest request) {
+        boolean isValidEmail = userService.checkEmail(request.getEmail());
+        return ResponseEntity.ok(new EmailCheckResponse(isValidEmail));
+    }
+
     @GetMapping
     public ResponseEntity<UserProfileDetailsResponse> getUserProfileDetails(@AuthUserId String userId) {
         UserProfileDetailsData userProfileDetailsData = userService.getUserProfileDetails(userId);

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -81,8 +81,9 @@ public class UserController {
     public ResponseEntity<EmailAuthValidationResponse> validateEmailAuth(@AuthUserId String userId,
                                                                 @RequestBody @Valid EmailAuthValidationRequest request) {
         EmailAuthValidationData emailAuthValidationData = userMapper.toEmailAuthValidationData(request);
-        User user = userEmailAuthService.validateEmailAuth(userId, emailAuthValidationData);
-        UserTokenData userTokenData = userTokenService.generateToken(user);
+        UserTokenData userTokenData = userEmailAuthService.validateEmailAuth(userId, emailAuthValidationData)
+                .map(userTokenService::generateToken)
+                .orElse(new UserTokenData());
         return ResponseEntity.ok(userMapper.toEmailAuthValidationResponse(userTokenData));
     }
 

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/EmailCheckRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/EmailCheckRequest.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import com.project.foradhd.global.validation.annotation.ValidEmail;
+import lombok.Getter;
+
+@Getter
+public class EmailCheckRequest {
+
+    @ValidEmail
+    private String email;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/EmailCheckRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/EmailCheckRequest.java
@@ -1,9 +1,13 @@
 package com.project.foradhd.domain.user.web.dto.request;
 
 import com.project.foradhd.global.validation.annotation.ValidEmail;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class EmailCheckRequest {
 
     @ValidEmail

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/NicknameCheckRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/NicknameCheckRequest.java
@@ -1,13 +1,9 @@
 package com.project.foradhd.domain.user.web.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class NicknameCheckRequest {
 
     @NotBlank(message = "{nickname.notBlank}")

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/NicknameCheckRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/NicknameCheckRequest.java
@@ -1,9 +1,13 @@
 package com.project.foradhd.domain.user.web.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class NicknameCheckRequest {
 
     @NotBlank(message = "{nickname.notBlank}")

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/response/EmailCheckResponse.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/response/EmailCheckResponse.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.user.web.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailCheckResponse {
+
+    private Boolean isValidEmail;
+}

--- a/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/mapper/UserMapper.java
@@ -39,8 +39,8 @@ public interface UserMapper {
     default SignUpData toSignUpData(SignUpRequest request) {
         User user = User.builder()
             .email(request.getEmail())
-            .role(Role.GUEST)
-            .isVerifiedEmail(Boolean.FALSE)
+            .role(Role.USER) //일반 회원가입 시 이메일 인증이 선제조건
+            .isVerifiedEmail(Boolean.TRUE)
             .build();
         UserPrivacy userPrivacy = UserPrivacy.builder()
             .user(user)

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -54,12 +54,12 @@ public class SecurityConfig {
 
     private static final String NICKNAME_CHECK_API_PATH = "/api/v1/user/nickname-check";
     private static final String EMAIL_CHECK_API_PATH = "/api/v1/user/email-check";
+    private static final String EMAIL_AUTH_API_PATH = "/api/v1/user/email-auth";
     private static final String SIGN_UP_API_PATH = "/api/v1/user/sign-up";
     private static final String LOGIN_API_PATH = "/api/v1/auth/login";
     private static final String AUTH_TOKEN_REISSUE_API_PATH = "/api/v1/auth/reissue";
     private static final String HEALTH_CHECK_API_PATH = "/api/v1/health-check";
 
-    private static final String EMAIL_AUTH_API_PATH = "/api/v1/user/email-auth";
     private static final String SNS_SIGN_UP_API_PATH = "/api/v1/user/sns-sign-up";
     private static final String WITHDRAW_API_PATH = "/api/v1/user/withdraw";
     private static final String LOGOUT_API_PATH = "/api/v1/auth/logout";
@@ -87,11 +87,11 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(registry -> registry
-                .requestMatchers(NICKNAME_CHECK_API_PATH, EMAIL_CHECK_API_PATH, SIGN_UP_API_PATH, LOGIN_API_PATH,
-                        AUTH_TOKEN_REISSUE_API_PATH, HEALTH_CHECK_API_PATH).permitAll()
+                .requestMatchers(NICKNAME_CHECK_API_PATH, EMAIL_CHECK_API_PATH, EMAIL_AUTH_API_PATH,
+                        SIGN_UP_API_PATH, LOGIN_API_PATH, AUTH_TOKEN_REISSUE_API_PATH, HEALTH_CHECK_API_PATH).permitAll()
                 .requestMatchers("/error", "/favicon.ico").permitAll()
                     .requestMatchers("/api/v1/notifications/sse").permitAll()
-                .requestMatchers(EMAIL_AUTH_API_PATH, SNS_SIGN_UP_API_PATH, WITHDRAW_API_PATH, LOGOUT_API_PATH).hasRole(Role.GUEST.name())
+                .requestMatchers(SNS_SIGN_UP_API_PATH, WITHDRAW_API_PATH, LOGOUT_API_PATH).hasRole(Role.GUEST.name())
                 .anyRequest().hasRole(Role.USER.name()))
             .sessionManagement(config -> config
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -44,8 +44,6 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Arrays;
 
@@ -55,6 +53,7 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private static final String NICKNAME_CHECK_API_PATH = "/api/v1/user/nickname-check";
+    private static final String EMAIL_CHECK_API_PATH = "/api/v1/user/email-check";
     private static final String SIGN_UP_API_PATH = "/api/v1/user/sign-up";
     private static final String LOGIN_API_PATH = "/api/v1/auth/login";
     private static final String AUTH_TOKEN_REISSUE_API_PATH = "/api/v1/auth/reissue";
@@ -88,8 +87,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(registry -> registry
-                .requestMatchers(NICKNAME_CHECK_API_PATH, SIGN_UP_API_PATH, LOGIN_API_PATH,
-                    AUTH_TOKEN_REISSUE_API_PATH, HEALTH_CHECK_API_PATH).permitAll()
+                .requestMatchers(NICKNAME_CHECK_API_PATH, EMAIL_CHECK_API_PATH, SIGN_UP_API_PATH, LOGIN_API_PATH,
+                        AUTH_TOKEN_REISSUE_API_PATH, HEALTH_CHECK_API_PATH).permitAll()
                 .requestMatchers("/error", "/favicon.ico").permitAll()
                     .requestMatchers("/api/v1/notifications/sse").permitAll()
                 .requestMatchers(EMAIL_AUTH_API_PATH, SNS_SIGN_UP_API_PATH, WITHDRAW_API_PATH, LOGOUT_API_PATH).hasRole(Role.GUEST.name())

--- a/src/test/java/com/project/foradhd/domain/user/business/service/UserEmailAuthServiceTest.java
+++ b/src/test/java/com/project/foradhd/domain/user/business/service/UserEmailAuthServiceTest.java
@@ -1,42 +1,128 @@
 package com.project.foradhd.domain.user.business.service;
 
+import com.project.foradhd.domain.user.business.dto.in.EmailAuthData;
 import com.project.foradhd.domain.user.business.dto.in.EmailAuthValidationData;
 import com.project.foradhd.domain.user.business.service.impl.UserEmailAuthServiceImpl;
+import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.global.exception.BusinessException;
 import com.project.foradhd.global.service.CacheService;
 import com.project.foradhd.global.service.EmailService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Optional;
 
+import static com.project.foradhd.domain.user.fixtures.UserFixtures.toUser;
 import static com.project.foradhd.global.enums.CacheKeyType.USER_EMAIL_AUTH_CODE;
 import static com.project.foradhd.global.exception.ErrorCode.EMAIL_AUTH_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @DisplayName("UserEmailAuthService 테스트")
-@ExtendWith(MockitoExtension.class)
+@TestPropertySource(properties = "cloud.aws.cloud-front.deploy-domain=test-domain")
+@Import(UserEmailAuthServiceImpl.class)
+@ExtendWith(SpringExtension.class)
 class UserEmailAuthServiceTest {
 
-    @InjectMocks
+    @Autowired
     UserEmailAuthServiceImpl userEmailAuthService;
 
-    @Mock
+    @MockBean
     UserService userService;
 
-    @Mock
+    @MockBean
     EmailService emailService;
 
-    @Mock
+    @MockBean
     CacheService cacheService;
+
+    @DisplayName("유저 이메일 인증코드 발급 테스트 : 성공 - GUEST 권한 이상 사용자")
+    @Test
+    void authenticate_email_test_with_guest_user() {
+        //given
+        String userId = "userId";
+        String email = "jkde7721@naver.com";
+        EmailAuthData emailAuthData = EmailAuthData.builder().email(email).build();
+
+        //when
+        userEmailAuthService.authenticateEmail(userId, emailAuthData);
+
+        //then
+        then(userService).should(never()).validateDuplicatedEmail(email);
+        then(userService).should(times(1)).validateDuplicatedEmail(email, userId);
+    }
+
+    @DisplayName("유저 이메일 인증코드 발급 테스트 : 성공 - 익명 사용자")
+    @Test
+    void authenticate_email_test_with_anonymous_user() {
+        //given
+        String userId = "anonymousUser";
+        String email = "jkde7721@naver.com";
+        EmailAuthData emailAuthData = EmailAuthData.builder().email(email).build();
+
+        //when
+        userEmailAuthService.authenticateEmail(userId, emailAuthData);
+
+        //then
+        then(userService).should(times(1)).validateDuplicatedEmail(email);
+        then(userService).should(never()).validateDuplicatedEmail(email, userId);
+    }
+
+    @DisplayName("유저 이메일 인증코드 검증 테스트 : 성공 - GUEST 권한 이상 사용자")
+    @Test
+    void validate_email_auth_test_with_guest_user() {
+        //given
+        String userId = "userId";
+        String email = "jkde7721@naver.com";
+        String authCode = "123456";
+        EmailAuthValidationData emailAuthValidationData = EmailAuthValidationData.builder()
+                .email(email)
+                .authCode(authCode)
+                .build();
+        User user = toUser().id(userId).build();
+        given(cacheService.getValue(USER_EMAIL_AUTH_CODE, email)).willReturn(Optional.of(authCode));
+        given(userService.updateEmailAuth(userId, email)).willReturn(user);
+
+        //when
+        Optional<User> optionalUser = userEmailAuthService.validateEmailAuth(userId, emailAuthValidationData);
+
+        //then
+        then(cacheService).should(times(1)).getValue(USER_EMAIL_AUTH_CODE, email);
+        then(userService).should(times(1)).updateEmailAuth(userId, email);
+        assertThat(optionalUser).contains(user);
+    }
+
+    @DisplayName("유저 이메일 인증코드 검증 테스트 : 성공 - 익명 사용자")
+    @Test
+    void validate_email_auth_test_with_anonymous_user() {
+        //given
+        String userId = "anonymousUser";
+        String email = "jkde7721@naver.com";
+        String authCode = "123456";
+        EmailAuthValidationData emailAuthValidationData = EmailAuthValidationData.builder()
+                .email(email)
+                .authCode(authCode)
+                .build();
+        given(cacheService.getValue(USER_EMAIL_AUTH_CODE, email)).willReturn(Optional.of(authCode));
+
+        //when
+        Optional<User> optionalUser = userEmailAuthService.validateEmailAuth(userId, emailAuthValidationData);
+
+        //then
+        then(cacheService).should(times(1)).getValue(USER_EMAIL_AUTH_CODE, email);
+        then(userService).should(never()).updateEmailAuth(userId, email);
+        assertThat(optionalUser).isEmpty();
+    }
 
     @DisplayName("유저 이메일 인증코드 검증 테스트 : 실패 - 인증 가능 시간 초과")
     @Test

--- a/src/test/java/com/project/foradhd/domain/user/business/service/UserServiceTest.java
+++ b/src/test/java/com/project/foradhd/domain/user/business/service/UserServiceTest.java
@@ -88,14 +88,27 @@ class UserServiceTest {
     void check_nickname_test() {
         //given
         String nickname = "ForA";
-        given(userProfileRepository.findByNickname(nickname))
-            .willReturn(Optional.empty());
+        given(userProfileRepository.findByNickname(nickname)).willReturn(Optional.empty());
 
         //when
         boolean isValidNickname = userService.checkNickname(nickname);
 
         //then
         assertThat(isValidNickname).isTrue();
+    }
+
+    @DisplayName("유저 이메일 중복 여부 확인 로직 테스트")
+    @Test
+    void check_email_test() {
+        //given
+        String email = "jkde7721@naver.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        //when
+        boolean isValidEmail = userService.checkEmail(email);
+
+        //then
+        assertThat(isValidEmail).isTrue();
     }
 
     @DisplayName("일반 회원가입 테스트 - 성공")

--- a/src/test/java/com/project/foradhd/domain/user/web/controller/UserControllerTest.java
+++ b/src/test/java/com/project/foradhd/domain/user/web/controller/UserControllerTest.java
@@ -28,6 +28,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.*;
@@ -338,7 +339,7 @@ class UserControllerTest {
         then(userEmailAuthService).should(times(1)).authenticateEmail(anyString(), any());
     }
 
-    @DisplayName("유저 이메일 인증용 메일 전송 컨트롤러 테스트 - 실패: 유효하지 않은 이메일")
+    @DisplayName("유저 이메일 인증용 메일 전송 컨트롤러 테스트 - 실패: 유효하지 않은 형식의 이메일")
     @Test
     void authenticate_email_test_fail_invalid_email() throws Exception {
         //given
@@ -376,6 +377,29 @@ class UserControllerTest {
                 .andDo(print());
         then(userEmailAuthService).should(times(1)).validateEmailAuth(anyString(), any());
         then(userTokenService).should(times(1)).generateToken(user);
+    }
+
+    @WithMockTestUser(userId = "anonymousUser")
+    @DisplayName("유저 이메일 인증 위한 인증 코드 검증 컨트롤러 테스트(익명 사용자인 경우)")
+    @Test
+    void validate_email_auth_test_with_anonymous_user() throws Exception {
+        //given
+        String anonymousUserId = "anonymousUser";
+        String email = "jkde7721@naver.com";
+        String authCode = "123456";
+        EmailAuthValidationRequest request = new EmailAuthValidationRequest(email, authCode);
+        given(userEmailAuthService.validateEmailAuth(eq(anonymousUserId), any())).willReturn(Optional.empty());
+
+        //when, then
+        mockMvc.perform(put("/api/v1/user/email-auth")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value(nullValue()))
+                .andExpect(jsonPath("$.refreshToken").value(nullValue()))
+                .andDo(print());
+        then(userEmailAuthService).should(times(1)).validateEmailAuth(eq(anonymousUserId), any());
+        then(userTokenService).should(never()).generateToken(any());
     }
 
     @DisplayName("유저 이메일 인증 위한 인증 코드 검증 컨트롤러 테스트 - 실패: 유효하지 않은 인증 코드(6자리 숫자)")


### PR DESCRIPTION
## 💻 구현 내용 

- 유저 이메일 중복 여부 확인 api 구현 및 테스트
- 기존 이메일 본인 인증코드 발급 및 검증 api 수정: 해당 api는 일반 회원가입 시 / 소셜 로그인 회원가입 시에만 호출 -> 전자는 `ROLE_ANONYMOUS` 권한으로, 후자는 `ROLE_GUEST` 권한으로 요청 -> 기존에는 `ROLE_GUEST` 권한 이상만 호출하도록 설정됨 -> 권한 제한 풀고 각 경우에 따라 다르게 처리하도록 수정(ex. `ROLE_GUEST` 권한인 경우 `userId`로 비교 수행)

## 🛠️ 개발 오류 사항

- `UserEmailAuthServiceTest`에서 `@MockitoExtension`, `@SpringExtension`을 같이 사용할 경우, `@InjectMocks`, `@Mock`이 제대로 동작하지 않는 문제: 모킹된 `UserService`의 특정 메소드를 분명 호출하였음에도 메소드 호출 여부 검증(`then(...).should(times(1))`) 시 `mockito wanted but not invoked, Actually there were zero interactions with this mock` 에러 발생
- `@SpringExtension` 어노테이션이 잘못 동작하는 것 같은데 이유는 알아보겠음
- 해결방법: `@SpringExtension`만 사용후, `@Mock` 대신 `@MockBean` 사용하여 목빈을 `@Import(UserEmailServiceImpl.class)`로 등록된 `UserEmailServiceImpl` 빈에 주입해줌

## 🗣️ For 리뷰어

- 기존의 닉네임 중복 여부 확인 api와 거의 유사합니다. 프론트 요구사항으로 approve하시면 바로 배포하겠습니다.

close #57