### PR TITLE
애플 로그인 시 CORS 에러 해결

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
@@ -3,11 +3,9 @@ package com.project.foradhd.domain.board.business.service.Impl;
 import com.project.foradhd.domain.board.business.service.CommentService;
 import com.project.foradhd.domain.board.persistence.entity.Comment;
 import com.project.foradhd.domain.board.persistence.entity.CommentLikeFilter;
-import com.project.foradhd.domain.board.persistence.entity.Post;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import com.project.foradhd.domain.board.persistence.repository.CommentLikeFilterRepository;
 import com.project.foradhd.domain.board.persistence.repository.CommentRepository;
-import com.project.foradhd.domain.board.web.dto.request.CreateCommentRequestDto;
 import com.project.foradhd.domain.board.web.dto.response.PostResponseDto;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserProfile;
@@ -19,7 +17,6 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -66,7 +63,7 @@ public class CommentServiceImpl implements CommentService {
 
         if (comment.isAnonymous()) {
             String anonymousNickname = generateAnonymousNickname(comment.getPost().getId(), userId);
-            String anonymousProfileImage = "http://example.com/anonymous-profile.png"; // 지정한 URL
+            String anonymousProfileImage = "image/default-profile.png";
 
             commentBuilder
                     .nickname(anonymousNickname)

--- a/src/main/java/com/project/foradhd/domain/board/web/controller/NotificationController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/NotificationController.java
@@ -11,8 +11,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
-@CrossOrigin(origins = {"http://localhost:3000", "http://localhost:8080"})
 public class NotificationController {
+
     private final NotificationService notificationService;
     private final SseEmitters sseEmitters;
 

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
@@ -11,8 +11,6 @@ import com.project.foradhd.domain.board.web.dto.response.PostSearchResponseDto;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserProfile;
-import com.project.foradhd.domain.user.persistence.repository.UserProfileRepository;
-import com.project.foradhd.domain.user.persistence.repository.UserRepository;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -23,9 +21,7 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.Context;
 
 import org.mapstruct.factory.Mappers;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -87,7 +83,7 @@ public interface PostMapper {
     default void setAnonymousOrUserProfile(@MappingTarget PostResponseDto.PostListResponseDto.PostListResponseDtoBuilder dto, Post post, @Context UserService userService) {
         if (post.isAnonymous()) {
             dto.nickname("익명");
-            dto.profileImage("http://example.com/default-profile.png");
+            dto.profileImage("image/default-profile.png");
         } else if (post.getUser() != null) {
             UserProfile userProfile = userService.getUserProfile(post.getUser().getId());
             if (userProfile != null) {

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.project.foradhd.global.config;
 
-import static org.springframework.http.HttpMethod.DELETE;
-import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.*;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 import com.project.foradhd.domain.auth.converter.CustomOAuth2AuthorizationCodeGrantRequestEntityConverter;
@@ -41,11 +40,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -63,8 +57,6 @@ public class SecurityConfig {
     private static final String SNS_SIGN_UP_API_PATH = "/api/v1/user/sns-sign-up";
     private static final String WITHDRAW_API_PATH = "/api/v1/user/withdraw";
     private static final String LOGOUT_API_PATH = "/api/v1/auth/logout";
-
-    private static final String CORS_ALLOWED_ORIGINS = "http://localhost:3000,http://localhost:8080";
 
     private static final RequestMatcher loginMatcher = new AntPathRequestMatcher(LOGIN_API_PATH, POST.name());
     private static final RequestMatcher logoutMatcher = new AntPathRequestMatcher(LOGOUT_API_PATH, DELETE.name());
@@ -95,6 +87,9 @@ public class SecurityConfig {
                 .anyRequest().hasRole(Role.USER.name()))
             .sessionManagement(config -> config
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            //if Spring MVC is on classpath and no CorsConfigurationSource is provided,
+            //Spring Security will use CORS configuration provided to Spring MVC
+            .cors(withDefaults())
             .csrf(CsrfConfigurer::disable)
             .httpBasic(HttpBasicConfigurer::disable)
             .formLogin(FormLoginConfigurer::disable)
@@ -114,7 +109,6 @@ public class SecurityConfig {
             .exceptionHandling(config -> config
                 .authenticationEntryPoint(jwtAuthenticationFailureHandler)
                 .accessDeniedHandler(jwtAuthorizationFailureHandler))
-                .cors(withDefaults())
             .addFilter(loginAuthenticationFilter(authenticationManager(authenticationConfiguration)))
             .addFilterAfter(jwtAuthenticationFilter, LoginAuthenticationFilter.class);
         return http.build();
@@ -155,17 +149,5 @@ public class SecurityConfig {
         DefaultAuthorizationCodeTokenResponseClient oAuth2AccessTokenResponseClient = new DefaultAuthorizationCodeTokenResponseClient();
         oAuth2AccessTokenResponseClient.setRequestEntityConverter(customOAuth2AuthorizationCodeGrantRequestEntityConverter);
         return oAuth2AccessTokenResponseClient;
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList(CORS_ALLOWED_ORIGINS.split(",")));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setAllowCredentials(true);
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 }

--- a/src/main/java/com/project/foradhd/global/config/WebConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.project.foradhd.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed.origins}")
+    private String[] allowedOrigins;
 
     @Bean
     public MessageSource messageSource() {
@@ -38,8 +42,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("http://localhost:3000", "http://localhost:8080")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,10 @@ google:
   places:
     url: ${GOOGLE_PLACES_URL}
 
+cors:
+  allowed:
+    origins: {CORS_ALLOWED_ORIGINS}
+
 ---
 spring:
   config:


### PR DESCRIPTION
## 💻 구현 내용 

- 애플 로그인 시 `https://appleid.apple.com` 도메인에서 직접 우리 서버 도메인으로 요청을 보내 CORS 에러 발생(naver, kakao, google 로그인과 달리 조금 다르게 구현되어 있는 듯)
- `WebConfig` 클래스 내 cors 설정에 해당 도메인 추가 (+ `SecurityConfig` 내 cors 설정 제거) 
- cors 설정을 환경변수로 주입하도록 변경 (환경변수 `CORS_ALLOWED_ORIGINS` 추가했습니다.)
- 댓글, 게시글 쪽 익명 유저에 대한 기본 프로필 이미지 경로 수정: cloud front 사용으로 S3 키로 설정하였습니다. (TODO: 디자인팀에 `default-profile.png` 이미지 파일 받은 후 S3 업로드 필요)

## 🛠️ 개발 오류 사항

## 🗣️ For 리뷰어

close #59 