### PR TITLE
약 게시글 조회 시 medicineId 추가

### DIFF
--- a/src/main/java/com/project/foradhd/domain/medicine/web/dto/MedicineDto.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/web/dto/MedicineDto.java
@@ -8,6 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class MedicineDto {
+    private Long medicineId;
     @SerializedName("ITEM_SEQ") private String itemSeq;
     @SerializedName("ITEM_NAME") private String itemName;
     @SerializedName("ENTP_SEQ") private String entpSeq;

--- a/src/main/java/com/project/foradhd/domain/medicine/web/dto/response/MedicineSearchResponse.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/web/dto/response/MedicineSearchResponse.java
@@ -22,5 +22,6 @@ public class MedicineSearchResponse {
         private String itemName;   // 약 이름
         private String itemEngName; // 약 영문명
         private String entpName;    // 제조사 이름
+        private Long medicineId;  // 약 ID
     }
 }

--- a/src/main/java/com/project/foradhd/domain/medicine/web/dto/response/MedicineSortedResponse.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/web/dto/response/MedicineSortedResponse.java
@@ -15,4 +15,5 @@ import java.util.List;
 public class MedicineSortedResponse {
     private String kind;
     private List<MedicineDto> medicineList;
+    private Long medicineId;
 }

--- a/src/main/java/com/project/foradhd/domain/medicine/web/mapper/MedicineMapper.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/web/mapper/MedicineMapper.java
@@ -15,11 +15,13 @@ import java.util.List;
 public interface MedicineMapper {
     Medicine toEntity(MedicineDto dto);
 
+    @Mapping(source = "id", target = "medicineId")
     MedicineDto toDto(Medicine entity);
 
     List<Medicine> toEntityList(List<MedicineDto> dtoList);
 
     List<MedicineResponse> toDtoList(List<Medicine> entityList);
+
     MedicineSearchResponse toResponseDto(Medicine entity);
     List<MedicineSearchResponse> toResponseDtoList(List<Medicine> entityList);
 
@@ -34,5 +36,6 @@ public interface MedicineMapper {
     @Mapping(source = "itemName", target = "itemName")
     @Mapping(source = "itemEngName", target = "itemEngName")
     @Mapping(source = "entpName", target = "entpName")
+    @Mapping(source = "id", target = "medicineId")
     MedicineSearchResponse.MedicineSearchListResponse toMedicineSearchListResponse(Medicine medicine);
 }


### PR DESCRIPTION
## 💻 구현 내용 
- 프론트쪽에서 약 게시물 목록 조회 시 응답값에 medicineId를 함께 내려달라는 요청을 받았습니다.
- 
<img width="995" alt="스크린샷 2024-09-29 오후 10 55 18" src="https://github.com/user-attachments/assets/ece06838-1486-4223-844f-034109c09238">
api 요청 시 응답값은 다음과 같습니다.

## 🛠️ 개발 오류 사항


## 🗣️ For 리뷰어

- medicinemapper, medicinesearchresponse, medicinedto에 각각 medicineId 추가한 것 이외에 수정사항 없습니다. 

close #61