### PR TITLE
Logback, AOP 이용한 로그 남기기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ src/main/resources/static/keys/**
 
 ### .csv 파일 ###
 *.csv
+
+### .log 파일 ###
+*.log

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,9 @@ dependencies {
 
 	//OpenCSV
 	implementation 'com.opencsv:opencsv:5.7.1'
+
+	//Spring AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/foradhd/domain/auth/filter/LoginAuthenticationFilter.java
+++ b/src/main/java/com/project/foradhd/domain/auth/filter/LoginAuthenticationFilter.java
@@ -15,10 +15,20 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Slf4j
 public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
+    private static final String REQUEST_LOG_FORMAT = """
+            [REQUEST]
+            API : {} {}
+            ClientIp : {}
+            Body : {}
+            """;
+
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request,
         HttpServletResponse response) throws AuthenticationException {
         LoginRequest loginRequest = extractLoginRequest(request);
+        log.info(REQUEST_LOG_FORMAT, request.getMethod(), request.getRequestURI(), request.getRemoteAddr(),
+                JsonUtil.writeValueAsString(loginRequest));
+
         UsernamePasswordAuthenticationToken authRequest = UsernamePasswordAuthenticationToken
             .unauthenticated(loginRequest.getUsername(), loginRequest.getPassword());
         return getAuthenticationManager().authenticate(authRequest);

--- a/src/main/java/com/project/foradhd/domain/auth/handler/LoginAuthenticationSuccessHandler.java
+++ b/src/main/java/com/project/foradhd/domain/auth/handler/LoginAuthenticationSuccessHandler.java
@@ -11,14 +11,22 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
+    private static final String RESPONSE_LOG_FORMAT = """
+            [RESPONSE]
+            Status : {},
+            Body : {}
+            """;
     private final UserService userService;
     private final JwtService jwtService;
 
@@ -33,6 +41,8 @@ public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessH
 
         Boolean hasVerifiedEmail = userService.hasVerifiedEmail(userDetails.getUserId());
         LoginResponse loginResponse = new LoginResponse(accessToken, refreshToken, hasVerifiedEmail);
+
+        log.info(RESPONSE_LOG_FORMAT, HttpStatus.OK, JsonUtil.writeValueAsString(loginResponse));
         response.setContentType(APPLICATION_JSON_VALUE);
         response.getWriter().write(JsonUtil.writeValueAsString(loginResponse));
     }

--- a/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/foradhd/global/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import com.project.foradhd.domain.auth.handler.OAuth2AuthenticationFailureHandle
 import com.project.foradhd.domain.auth.handler.OAuth2AuthenticationSuccessHandler;
 import com.project.foradhd.domain.user.persistence.enums.Role;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
@@ -128,6 +129,24 @@ public class SecurityConfig {
         loginAuthenticationFilter.setAuthenticationSuccessHandler(loginAuthenticationSuccessHandler);
         loginAuthenticationFilter.setAuthenticationFailureHandler(loginAuthenticationFailureHandler);
         return loginAuthenticationFilter;
+    }
+
+    //LoginAuthenticationFilter 서블릿 컨테이너(ApplicationFilterChain)에 등록되지 않도록 설정
+    @Bean
+    public FilterRegistrationBean<LoginAuthenticationFilter> loginAuthenticationFilterRegistrationBean(AuthenticationManager authenticationManager) {
+        FilterRegistrationBean<LoginAuthenticationFilter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(loginAuthenticationFilter(authenticationManager));
+        filterRegistrationBean.setEnabled(false);
+        return filterRegistrationBean;
+    }
+
+    //JwtAuthenticationFilter 서블릿 컨테이너(ApplicationFilterChain)에 등록되지 않도록 설정
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtAuthenticationFilterRegistrationBean() {
+        FilterRegistrationBean<JwtAuthenticationFilter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(jwtAuthenticationFilter);
+        filterRegistrationBean.setEnabled(false);
+        return filterRegistrationBean;
     }
 
     @Bean

--- a/src/main/java/com/project/foradhd/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/foradhd/global/exception/handler/GlobalExceptionHandler.java
@@ -102,5 +102,4 @@ public class GlobalExceptionHandler {
         }
         return defaultMessage;
     }
-
 }

--- a/src/main/java/com/project/foradhd/global/filter/RequestWrapperFilter.java
+++ b/src/main/java/com/project/foradhd/global/filter/RequestWrapperFilter.java
@@ -1,0 +1,25 @@
+package com.project.foradhd.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.IOException;
+
+@Order //필터 순서 마지막
+@Component
+public class RequestWrapperFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        //Request 객체의 InputStream을 여러번 읽을 수 있도록 wrapping (logging을 위해)
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+        filterChain.doFilter(requestWrapper, response);
+    }
+}

--- a/src/main/java/com/project/foradhd/global/logging/logger/ApiLogger.java
+++ b/src/main/java/com/project/foradhd/global/logging/logger/ApiLogger.java
@@ -1,0 +1,63 @@
+package com.project.foradhd.global.logging.logger;
+
+import com.project.foradhd.global.util.HeaderUtil;
+import com.project.foradhd.global.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@Aspect
+public class ApiLogger {
+
+    private static final String REQUEST_LOG_FORMAT = """
+            [REQUEST]
+            API : {} {}
+            Token : {}
+            ClientIp : {}
+            Body : {}
+            """;
+    private static final String RESPONSE_LOG_FORMAT = """
+            [RESPONSE]
+            Status : {},
+            Body : {}
+            """;
+    private final HeaderUtil headerUtil;
+
+    //-Controller 메소드 호출 시 동작하는 포인트컷 표현식
+    @Around("""
+        execution(public * com.project.foradhd..*Controller.*(..))
+    """)
+    public Object logging(ProceedingJoinPoint joinPoint) throws Throwable {
+        loggingRequest();
+        Object result = joinPoint.proceed();
+        loggingResponse(result);
+        return result;
+    }
+
+    private void loggingRequest() {
+        if (RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes servletRequestAttributes &&
+                servletRequestAttributes.getRequest() instanceof ContentCachingRequestWrapper request) {
+            log.info(REQUEST_LOG_FORMAT, request.getMethod(), request.getRequestURI(), headerUtil.parseToken(request).orElse(""),
+                    request.getRemoteAddr(), request.getContentAsString());
+        }
+    }
+
+    private void loggingResponse(Object result) {
+        if (result instanceof ResponseEntity<?> response)
+            log.info(RESPONSE_LOG_FORMAT, response.getStatusCode(), JsonUtil.writeValueAsString(response.getBody()));
+        else {
+            log.info(RESPONSE_LOG_FORMAT, HttpStatus.OK, result);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,17 @@ google:
 
 cors:
   allowed:
-    origins: {CORS_ALLOWED_ORIGINS}
+    origins: ${CORS_ALLOWED_ORIGINS}
+
+log:
+  config:
+    path: ${LOG_PATH}
+    filename:
+      application: ${LOG_APPLICATION_FILENAME}
+      error: ${LOG_ERROR_FILENAME}
+    maxHistory: ${LOG_MAX_HISTORY}
+    maxFileSize: ${LOG_MAX_FILE_SIZE}
+    totalSizeCap: ${LOG_TOTAL_SIZE_CAP}
 
 ---
 spring:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 60초마다 설정 파일의 변경 확인하여 변경 시 재로딩 -->
+<configuration scan="true" scanPeriod="60 seconds">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" /> <!-- FILE_LOG_PATTERN 변수 사용 위해 -->
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" /> <!-- CONSOLE appender 사용 위해 -->
+
+    <!-- 로그 변수 값 설정 (application.yml 파일에서 설정) -->
+    <springProperty name="LOG_PATH" source="log.config.path"/>
+    <springProperty name="LOG_FILENAME" source="log.config.filename.application"/>
+    <springProperty name="LOG_ERROR_FILENAME" source="log.config.filename.error"/>
+    <springProperty name="LOG_MAX_HISTORY" source="log.config.maxHistory"/>
+    <springProperty name="LOG_MAX_FILE_SIZE" source="log.config.maxFileSize"/>
+    <springProperty name="LOG_TOTAL_SIZE_CAP" source="log.config.totalSizeCap"/>
+
+    <!-- spring profiles dev 또는 prod 경우 appender 설정 -->
+    <springProfile name="dev, prod">
+        <!-- 여러 파일을 순회하면서 로그 기록하는 appender -->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <!-- 로그 파일 이름 설정 -->
+            <file>${LOG_PATH}/${LOG_FILENAME}.log</file>
+            <!-- 로그 패턴 설정 -->
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+            <!-- 날짜가 바뀌거나 해당 파일 용량이 다 차면 다른 파일에 로그 기록 -->
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/${LOG_FILENAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <!-- 로그 파일 분할 기준 용량 -->
+                <maxFileSize>${LOG_MAX_FILE_SIZE}</maxFileSize>
+                <!-- 저장된 로그 파일 해당 기간(일 단위) 지나면 삭제 -->
+                <maxHistory>${LOG_MAX_HISTORY}</maxHistory>
+                <!-- 전체 로그 파일 크기 제한, 초과 시 가장 오래된 파일 삭제 -->
+                <totalSizeCap>${LOG_TOTAL_SIZE_CAP}</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <!-- ERROR 레벨 로그만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+
+            <file>${LOG_PATH}/${LOG_ERROR_FILENAME}.log</file>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/${LOG_ERROR_FILENAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>${LOG_MAX_FILE_SIZE}</maxFileSize>
+                <maxHistory>${LOG_MAX_HISTORY}</maxHistory>
+                <totalSizeCap>${LOG_TOTAL_SIZE_CAP}</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+    </springProfile>
+
+    <!-- spring profiles local 경우 root logger 설정 -->
+    <!-- local profiles: DEBUG 레벨 로그 콘솔에 출력 (기존 스프링 로그 방식과 동일) -->
+    <springProfile name="local">
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
+
+    <!-- spring profiles dev 경우 root logger 설정 -->
+    <!-- dev profiles: DEBUG 레벨 로그 콘솔에 출력 및 파일에 저장 + ERROR 레벨 로그 파일에 저장 -->
+    <springProfile name="dev">
+        <!-- root: 로그 레벨 전역 설정, logger: 로그 레벨 지역 설정 -->
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE" />
+            <appender-ref ref="FILE" />
+            <appender-ref ref="ERROR_FILE" />
+        </root>
+    </springProfile>
+
+    <!-- spring profiles prod 경우 root logger 설정 -->
+    <!-- prod profiles: INFO 레벨 로그 콘솔에 출력 및 파일에 저장 + ERROR 레벨 로그 파일에 저장 -->
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+            <appender-ref ref="FILE" />
+            <appender-ref ref="ERROR_FILE" />
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 💻 구현 내용 

Spring Logback, AOP를 이용하여 로그를 남김

### Spring Logback 

- `src/main/resources/logback-spring.xml` 경로의 파일을 생성하여 실행 프로필(`local`, `dev`, `prod`) 별로 다른 로깅 방식을 취함
- `include` 태그를 통해 기본 설정값(`defaults.xml`, `console-appender.xml`)을 재사용
  ```xml 
  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
  <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
  ```
- `springPropery` 태그를 통해 logback-spring.xml 파일 내에서 사용할 변수 선언 
  ```xml
  <!-- 로그 변수 값 설정 (application.yml 파일에서 설정) -->
  <springProperty name="LOG_PATH" source="log.config.path"/>
  <springProperty name="LOG_FILENAME" source="log.config.filename.application"/>
  <springProperty name="LOG_ERROR_FILENAME" source="log.config.filename.error"/>
  <springProperty name="LOG_MAX_HISTORY" source="log.config.maxHistory"/>
  <springProperty name="LOG_MAX_FILE_SIZE" source="log.config.maxFileSize"/>
  <springProperty name="LOG_TOTAL_SIZE_CAP" source="log.config.totalSizeCap"/>
  ```
- `springProfile` 태그를 통해 해당 설정을 적용할 실행 환경 지정
  ```xml
  <!-- spring profiles dev 또는 prod 경우 설정 -->
  <springProfile name="dev, prod">
     <!-- ... -->
  </springProfile>
  ```
- 실행 프로필별 설정값
  - 실행 환경에 따라 각기 다른 logger 동작
  - `local`: DEBUG 레벨의 console logger(콘솔에 로그 출력 - 휘발성)
  - `dev`: DEBUG 레벨의 console, file logger(파일에 로그 출력 - 비휘발성) + ERROR 레벨의 file logger
  - `prod`: INFO 레벨의 console, file logger + ERROR 레벨의 file logger

### Spring AOP

- 로그를 남기는 것은 횡단 관심사, 즉 모든 API에 대해 공통적인 로직이므로 Spring AOP 적용
- 모든 API 전후로 요청 및 응답을 로그로 남김
- 포인트컷 설정: `execution(public * com.project.foradhd..*Controller.*(..))` -> 모든 `-Controller` 메소드 호출 시 동작하는 포인트컷 표현식
- 로그 형식
  ```
  [REQUEST]
  API : {} {}
  Token : {}
  ClientIp : {}
  Body : {}
  
  [RESPONSE]
  Status : {},
  Body : {}
  ```

### 참고
https://velog.io/@woosim34/Springboot-Logback-%EC%84%A4%EC%A0%95%ED%95%B4%EB%B3%B4%EA%B8%B0#%E2%97%8B-logback-log-level
https://amaran-th.github.io/Spring/[Spring]%20Logback%EC%9C%BC%EB%A1%9C%20%EB%A1%9C%EA%B9%85(Logging)%ED%95%98%EA%B8%B0/
https://velog.io/@dktlsk6/logback-%EC%84%A4%EC%A0%95
https://backtony.tistory.com/33
https://colabear754.tistory.com/204#%EC%9D%B4%EC%A0%9C_%EB%A1%9C%EA%B7%B8%EB%A5%BC_%EA%B8%B0%EB%A1%9D%ED%95%98%EB%8A%94_%EB%A1%9C%EC%A7%81%EC%9D%84_%EC%9E%91%EC%84%B1%ED%95%B4%EB%B3%B4%EC%9E%90!

## 🛠️ 개발 오류 사항

### `ApiLogger`에서 요청 바디 로그를 남길 때 `getInputStream() has already been called for this request` 에러 발생 
  - 원인: `HttpServletRequest` 객체의 `InputStream`은 딱 한번만 읽을 수 있음, 만약 `Controller`의 메소드 파라미터로 `@RequestBody` 어노테이션이 선언된 객체를 주입해주는 `HandlerMethodArgumentResolver` 구현체가 `InputStream`을 읽은 후 `ApiLogger`에서 다시 읽어버리면, 위 에러 발생
  - `InputStream`을 여러번 읽을 수 있도록 기존의 `HttpServletRequest` 객체를 `ContentCachingRequestWrapper`로 한번더 wrapping 
  - `RequestWrapperFilter`가 해당 역할을 수행하며, `ApplicationFilterChain`의 마지막 순서로 등록됨 (`WsFilter` 바로 앞) -> 순서를 제일 첫번째로 등록하면 `ContentCachingRequestWrapper` 객체가 아닌 `Servlet3SecurityContextHolderAwareRequestWrapper` 객체로 감싸지는데 `ApplicationFilterChain`의 `filters` 순서 상 wrapping 순서가 꼬이는 듯? 

### `ApplicationFilterChain`에 등록된 시큐리티 관련 필터들
  - `LoginAuthenticationFilter`, `JwtAuthenticationFilter`는 시큐리티 관련 필터로, `SecurityFilterChain`에 등록됨
  - 해당 필터들은 `Filter` 인터페이스를 구현하면서 `@Component` 어노테이션 선언으로 빈 등록되어 `ApplicationFilterChain`에도 포함된 것을 확인
  - 즉 하나의 요청에 대해 해당 필터들은 2번 타게 됨
  - 다음과 같이 설정하여 `ApplicationFilterChain`(서블릿 컨테이너)에는 등록되지 않고, `SecurityFilterChain`에만 등록되도록 설정
    ```java
    @Bean
    public FilterRegistrationBean<LoginAuthenticationFilter> loginAuthenticationFilterRegistrationBean(AuthenticationManager authenticationManager) {
        FilterRegistrationBean<LoginAuthenticationFilter> filterRegistrationBean = new FilterRegistrationBean<>();
        filterRegistrationBean.setFilter(loginAuthenticationFilter(authenticationManager));
        filterRegistrationBean.setEnabled(false); //서블릿 컨테이너에 등록X
        return filterRegistrationBean;
    }

    @Bean
    public FilterRegistrationBean<JwtAuthenticationFilter> jwtAuthenticationFilterRegistrationBean() {
        FilterRegistrationBean<JwtAuthenticationFilter> filterRegistrationBean = new FilterRegistrationBean<>();
        filterRegistrationBean.setFilter(jwtAuthenticationFilter);
        filterRegistrationBean.setEnabled(false); //서블릿 컨테이너에 등록X
        return filterRegistrationBean;
    }
    ```

### 참고 
https://leeyongjin.tistory.com/entry/request-response-logging
https://twofootdog.github.io/Spring-POST%EB%B0%A9%EC%8B%9D%EC%9C%BC%EB%A1%9C-%EC%A0%84%EB%8B%AC%EB%90%9C-JSON-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0/
https://bitgadak.tistory.com/10
https://www.inflearn.com/community/questions/1027744/%EC%BB%A4%EC%8A%A4%ED%85%80-%ED%95%84%ED%84%B0-%EB%93%B1%EB%A1%9D-%EC%8B%9C-applicationfilterchain-%EC%97%90-%EB%93%B1%EB%A1%9D?srsltid=AfmBOoqQ-te8L8OOUKQSCbGgwx1w_Bq5augrwtzVWVH1jVSotpom2noI

## 🗣️ For 리뷰어

- 추가된 환경변수: `LOG_PATH`, `LOG_APPLICATION_FILENAME`, `LOG_ERROR_FILENAME`, `LOG_MAX_HISTORY`, `LOG_MAX_FILE_SIZE`, `LOG_TOTAL_SIZE_CAP` 추가되었습니다. 노션 확인 부탁드려요
- 각 실행 환경 별 설정값대로 로그가 잘 남는지 확인해주세요.
- 서현님 노트북으로 실행할 때 환경변수 중 `LOG_PATH`는 노션에 작성된 값이 아닌 서현님 환경에서 로그 파일을 남기고 싶은 디렉토리의 절대 경로 설정해주시면 됩니다. 

close #64 