### PR TITLE
병원 상세 조회 api 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/hospital/business/dto/out/HospitalDetailsData.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/dto/out/HospitalDetailsData.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class HospitalDetailsData {
 
     private Hospital hospital;
+    private Double distance;
     private Boolean isBookmarked;
     private Boolean isEvaluationReviewed;
     private List<Doctor> doctorList;

--- a/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalService.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/service/HospitalService.java
@@ -4,6 +4,8 @@ import com.project.foradhd.domain.hospital.business.dto.in.*;
 import com.project.foradhd.domain.hospital.business.dto.out.*;
 import com.project.foradhd.domain.hospital.persistence.entity.*;
 import com.project.foradhd.domain.hospital.web.enums.HospitalReviewFilter;
+import com.project.foradhd.global.util.GeoUtil;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -21,7 +23,9 @@ public interface HospitalService {
 
     DoctorBriefListData getDoctorBriefList(String hospitalId);
 
-    HospitalDetailsData getHospitalDetails(String userId, String hospitalId);
+    HospitalDetailsData getHospitalDetails(String userId, String hospitalId, Double latitude, Double longitude);
+
+    Double getHospitalDistance(Double latitude, Double longitude, Point hospitalLocation);
 
     Hospital getHospital(String hospitalId);
 

--- a/src/main/java/com/project/foradhd/domain/hospital/business/service/impl/HospitalServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/business/service/impl/HospitalServiceImpl.java
@@ -16,8 +16,10 @@ import com.project.foradhd.domain.user.persistence.entity.UserProfile;
 import com.project.foradhd.global.exception.BusinessException;
 import com.project.foradhd.global.exception.ErrorCode;
 import com.project.foradhd.global.paging.web.dto.response.PagingResponse;
+import com.project.foradhd.global.util.GeoUtil;
 import com.project.foradhd.global.util.JsonUtil;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -136,7 +138,7 @@ public class HospitalServiceImpl implements HospitalService {
     }
 
     @Override
-    public HospitalDetailsData getHospitalDetails(String userId, String hospitalId) {
+    public HospitalDetailsData getHospitalDetails(String userId, String hospitalId, Double latitude, Double longitude) {
         Hospital hospital = getHospital(hospitalId);
         List<Doctor> doctorList = doctorRepository.findAllByHospitalIdOrderByName(hospitalId);
         HospitalBookmark notHospitalBookmark = HospitalBookmark.builder().deleted(true).build();
@@ -145,10 +147,17 @@ public class HospitalServiceImpl implements HospitalService {
         boolean isEvaluationReviewed = hospitalEvaluationReviewRepository.findByUserIdAndHospitalId(userId, hospitalId).isPresent();
         return HospitalDetailsData.builder()
                 .hospital(hospital)
+                .distance(getHospitalDistance(latitude, longitude, hospital.getLocation()))
                 .isBookmarked(!hospitalBookmark.getDeleted())
                 .isEvaluationReviewed(isEvaluationReviewed)
                 .doctorList(doctorList)
                 .build();
+    }
+
+    @Override
+    public Double getHospitalDistance(Double latitude, Double longitude, Point hospitalLocation) {
+        return latitude == null || longitude == null ? null :
+                GeoUtil.calculateDistance(latitude, longitude, hospitalLocation.getY(), hospitalLocation.getX());
     }
 
     @Override

--- a/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/controller/HospitalController.java
@@ -96,8 +96,10 @@ public class HospitalController {
 
     @GetMapping("/{hospitalId}")
     public ResponseEntity<HospitalDetailsResponse> getHospitalDetails(@AuthUserId String userId,
-                                                                    @PathVariable String hospitalId) {
-        HospitalDetailsData hospitalDetailsData = hospitalService.getHospitalDetails(userId, hospitalId);
+                                                                    @PathVariable String hospitalId,
+                                                                    @ModelAttribute HospitalDetailsRequest request) {
+        HospitalDetailsData hospitalDetailsData = hospitalService.getHospitalDetails(userId, hospitalId,
+                request.getLatitude(), request.getLongitude());
         HospitalDetailsResponse hospitalDetailsResponse = hospitalMapper.toHospitalDetailsResponse(hospitalDetailsData);
 
         String placeId = hospitalDetailsData.getHospital().getPlaceId();

--- a/src/main/java/com/project/foradhd/domain/hospital/web/dto/request/HospitalDetailsRequest.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/dto/request/HospitalDetailsRequest.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.hospital.web.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class HospitalDetailsRequest {
+
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalDetailsResponse.java
+++ b/src/main/java/com/project/foradhd/domain/hospital/web/dto/response/HospitalDetailsResponse.java
@@ -21,6 +21,7 @@ public class HospitalDetailsResponse {
     private Double longitude;
     private Integer totalReceiptReviewCount;
     private Integer totalEvaluationReviewCount;
+    private Double distance;
     private Boolean isBookmarked;
     private Boolean isEvaluationReviewed;
     private HospitalOperationStatus operationStatus;

--- a/src/main/java/com/project/foradhd/global/util/GeoUtil.java
+++ b/src/main/java/com/project/foradhd/global/util/GeoUtil.java
@@ -1,0 +1,23 @@
+package com.project.foradhd.global.util;
+
+public abstract class GeoUtil {
+
+    // 지구의 반지름(m 단위)
+    private static final double EARTH_RADIUS = 6371000;
+
+    public static double calculateDistance(double latitude1, double longitude1, double latitude2, double longitude2) {
+        //위도와 경도를 라디안으로 변환
+        double latitudeDistance = Math.toRadians(latitude2 - latitude1);
+        double longitudeDistance = Math.toRadians(longitude2 - longitude1);
+
+        //해버사인 공식 사용
+        double a = Math.sin(latitudeDistance / 2) * Math.sin(latitudeDistance / 2)
+                + Math.cos(Math.toRadians(latitude1)) * Math.cos(Math.toRadians(latitude2))
+                * Math.sin(longitudeDistance / 2) * Math.sin(longitudeDistance / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        //지구의 반지름을 곱해 최종 거리 반환 (m 단위)
+        return EARTH_RADIUS * c;
+    }
+}

--- a/src/test/java/com/project/foradhd/domain/hospital/business/service/HospitalServiceTest.java
+++ b/src/test/java/com/project/foradhd/domain/hospital/business/service/HospitalServiceTest.java
@@ -83,6 +83,8 @@ class HospitalServiceTest {
         //given
         String userId = "userId";
         String hospitalId = "hospitalId";
+        Double latitude = 37.4867657;
+        Double longitude = 127.1031943;
         Doctor doctor = toDoctor().build();
         given(hospitalRepository.findById(hospitalId)).willReturn(Optional.of(toHospital().build()));
         given(doctorRepository.findAllByHospitalIdOrderByName(hospitalId)).willReturn(List.of(doctor));
@@ -90,13 +92,14 @@ class HospitalServiceTest {
         given(hospitalEvaluationReviewRepository.findByUserIdAndHospitalId(userId, hospitalId)).willReturn(Optional.empty());
 
         //when
-        HospitalDetailsData hospitalDetails = hospitalService.getHospitalDetails(userId, hospitalId);
+        HospitalDetailsData hospitalDetails = hospitalService.getHospitalDetails(userId, hospitalId, latitude, longitude);
 
         //then
         then(hospitalRepository).should(times(1)).findById(hospitalId);
         then(doctorRepository).should(times(1)).findAllByHospitalIdOrderByName(hospitalId);
         then(hospitalBookmarkRepository).should(times(1)).findById(userId, hospitalId);
         then(hospitalEvaluationReviewRepository).should(times(1)).findByUserIdAndHospitalId(userId, hospitalId);
+        assertThat(hospitalDetails.getDistance()).isNotNull();
         assertThat(hospitalDetails.getIsBookmarked()).isFalse();
         assertThat(hospitalDetails.getIsEvaluationReviewed()).isFalse();
     }


### PR DESCRIPTION
## 💻 구현 내용 

- 병원 상세 조회 `GET /api/v1/hospitals/{hospitalId}` api에 요청 파라미터 `latitude`, `longitude` 및 응답 바디로 `distance`(현재 위치에서 병원까지의 거리) 값 추가

## 🗣️ For 리뷰어

- 요청 파라미터로 전달된 위경도 좌표값과 DB에서 조회된 병원의 좌표값 사이의 거리를 구하는 유틸 클래스 `GeoUtil` 추가 구현하였습니다. 참고로 내 주변 병원 목록 조회 api에서는 자바단이 아닌 sql(`st_distance_sphere` 함수 사용)에서 현재 위치 - 병원 간의 거리를 구하고 있습니다. 
- 채은님 요청으로 api 수정하였습니다. 리뷰해주시면 바로 배포하겠습니다. 

close #67