### PR TITLE
mod: 게시글 검색 시 postid 내려주도록 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostSearchResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostSearchResponseDto.java
@@ -23,6 +23,7 @@ public class PostSearchResponseDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class PostSearchListResponseDto {
+        private long id;
         private String title;
         private long viewCount;
         private long likeCount;


### PR DESCRIPTION
## 💻 구현 내용 

- 게시글 제목으로 검색 시 상세페이지 이동을 위해 응답 dto에 postid를 함께 포함하여 내려달라는 프론트측의 요청 반영하였습니다
- 추가된 것 postsearchreseponsedto에 id값 추가한 것 이외 수정사항 없습니다.

## 🛠️ 개발 오류 사항

## 🗣️ For 리뷰어
<img width="1014" alt="스크린샷 2024-10-09 오후 9 50 02" src="https://github.com/user-attachments/assets/e5ae91d0-83da-424d-9c73-b9e9d725a608">
위와 같이 postid 함께 응답값에 포함됩니다.

close #72