### PR TITLE
mod: postsearch 응답 dto에 postid값 추가

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostSearchResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostSearchResponseDto.java
@@ -23,6 +23,7 @@ public class PostSearchResponseDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class PostSearchListResponseDto {
+        private Long id;
         private String title;
         private long viewCount;
         private long likeCount;


### PR DESCRIPTION
## 💻 구현 내용 
- 게시글 제목으로 검색 시 해당 게시물을 클릭하면 바로 이동하기 위해 postid값 추가하였습니다 (저번에 수정해서 머지한 것 같은데, 다시 develop 브랜치 풀 받아서 해보니까 안 되더라구요)
- postsearchresponsedto 이외 수정사항 없습니다.

## 🛠️ 개발 오류 사항


## 🗣️ For 리뷰어

close #75 