### PR TITLE
유저 차단 기능 구현

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/business/service/CommentService.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/CommentService.java
@@ -1,13 +1,10 @@
 package com.project.foradhd.domain.board.business.service;
 
 import com.project.foradhd.domain.board.persistence.entity.Comment;
-import com.project.foradhd.domain.board.persistence.entity.Post;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
-import com.project.foradhd.domain.board.web.dto.request.CreateCommentRequestDto;
-import com.project.foradhd.domain.board.web.dto.response.PostResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.PostListResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface CommentService {
     Comment getComment(Long commentId);
@@ -15,7 +12,7 @@ public interface CommentService {
     void deleteComment(Long commentId);
     void deleteChildrenComment(Long commentId);
     Comment updateComment(Long commentId, String content, boolean anonymous, String userId);
-    Page<PostResponseDto.PostListResponseDto> getMyCommentedPosts(String userId, Pageable pageable, SortOption sortOption);
+    Page<PostListResponseDto.PostResponseDto> getMyCommentedPosts(String userId, Pageable pageable, SortOption sortOption);
     Page<Comment> getCommentsByPost(Long postId, Pageable pageable, SortOption sortOption);
     void toggleCommentLike(Long commentId, String userId);
     String generateAnonymousNickname(Long postId, String userId);

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
@@ -6,7 +6,7 @@ import com.project.foradhd.domain.board.persistence.entity.CommentLikeFilter;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import com.project.foradhd.domain.board.persistence.repository.CommentLikeFilterRepository;
 import com.project.foradhd.domain.board.persistence.repository.CommentRepository;
-import com.project.foradhd.domain.board.web.dto.response.PostResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.PostListResponseDto;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserProfile;
@@ -118,7 +118,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public Page<PostResponseDto.PostListResponseDto> getMyCommentedPosts(String userId, Pageable pageable, SortOption sortOption) {
+    public Page<PostListResponseDto.PostResponseDto> getMyCommentedPosts(String userId, Pageable pageable, SortOption sortOption) {
         Sort sort = switch (sortOption) {
             case OLDEST_FIRST -> Sort.by(Sort.Direction.ASC, "createdAt");
             case NEWEST_FIRST -> Sort.by(Sort.Direction.DESC, "createdAt");
@@ -127,10 +127,10 @@ public class CommentServiceImpl implements CommentService {
         Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
         Page<Comment> userComments = commentRepository.findByUserId(userId, sortedPageable);
-        List<PostResponseDto.PostListResponseDto> posts = userComments.stream()
+        List<PostListResponseDto.PostResponseDto> posts = userComments.stream()
                 .map(Comment::getPost)
                 .distinct()
-                .map(post -> PostResponseDto.PostListResponseDto.builder()
+                .map(post -> PostListResponseDto.PostResponseDto.builder()
                         .id(post.getId())
                         .title(post.getTitle())
                         .content(post.getContent())

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostLikeFilterServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostLikeFilterServiceImpl.java
@@ -14,7 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.project.foradhd.global.exception.ErrorCode.BOARD_NOT_FOUND;
+import static com.project.foradhd.global.exception.ErrorCode.NOT_FOUND_POST;
 
 
 @Service
@@ -30,7 +30,7 @@ public class PostLikeFilterServiceImpl implements PostLikeFilterService {
     @Transactional
     public void toggleLike(String userId, Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new BusinessException(BOARD_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
 
         User user = userService.getUser(userId);
 

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostScrapFilterServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostScrapFilterServiceImpl.java
@@ -34,7 +34,7 @@ public class PostScrapFilterServiceImpl implements PostScrapFilterService {
     @Transactional
     public void toggleScrap(Long postId, String userId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.BOARD_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_POST));
         User user = userService.getUser(userId);
 
         postScrapFilterRepository.findByPostIdAndUserId(postId, userId)

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.project.foradhd.global.exception.ErrorCode.BOARD_NOT_FOUND;
+import static com.project.foradhd.global.exception.ErrorCode.NOT_FOUND_POST;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +34,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post getPost(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new BusinessException(BOARD_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
     }
 
     @Override
@@ -126,7 +126,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public void addComment(Long postId, String commentContent, String userId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new BusinessException(BOARD_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_POST));
 
         String message = "새로운 댓글이 달렸어요: " + commentContent;
         notificationService.createNotification(post.getUser().getId(), message);

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
@@ -27,7 +27,7 @@ import static com.project.foradhd.global.exception.ErrorCode.BOARD_NOT_FOUND;
 public class PostServiceImpl implements PostService {
 
     private final PostRepository postRepository;
-    private final PostSearchHistoryService searchHistoryService;
+    private final PostSearchHistoryService postSearchHistoryService;
     private final NotificationService notificationService;
     private final SseEmitters sseEmitters;
 
@@ -156,14 +156,14 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<String> getRecentSearchTerms(String userId) {
-        return searchHistoryService.getRecentSearchTerms(userId);
+        return postSearchHistoryService.getRecentSearchTerms(userId);
     }
 
     @Override
     @Transactional
     public Page<Post> searchPostsByTitle(String title, String userId, Pageable pageable) {
         // 검색어 저장 로직 추가
-        searchHistoryService.saveSearchTerm(userId, title);
+        postSearchHistoryService.saveSearchTerm(userId, title);
         return postRepository.findByTitleContainingWithUserProfile(title, pageable);
     }
 }

--- a/src/main/java/com/project/foradhd/domain/board/web/controller/CommentController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/CommentController.java
@@ -4,22 +4,12 @@ import com.project.foradhd.domain.board.persistence.entity.Comment;
 import com.project.foradhd.domain.board.business.service.CommentService;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import com.project.foradhd.domain.board.web.dto.request.CreateCommentRequestDto;
-import com.project.foradhd.domain.board.web.dto.response.CommentResponseDto;
-import com.project.foradhd.domain.board.web.dto.response.PostResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.CommentListResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.PostListResponseDto;
 import com.project.foradhd.domain.board.web.mapper.CommentMapper;
 import com.project.foradhd.domain.user.persistence.repository.UserRepository;
 import com.project.foradhd.global.AuthUserId;
 import com.project.foradhd.global.paging.web.dto.response.PagingResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,17 +31,17 @@ public class CommentController {
 
     // 개별 댓글 조회 API
     @GetMapping("/{commentId}")
-    public ResponseEntity<CommentResponseDto.CommentListResponseDto> getComment(@PathVariable Long commentId) {
+    public ResponseEntity<CommentListResponseDto.CommentResponseDto> getComment(@PathVariable Long commentId) {
         Comment comment = commentService.getComment(commentId);
         return ResponseEntity.ok(commentMapper.commentToCommentListResponseDto(comment));
     }
 
     // 댓글 작성 API
     @PostMapping
-    public ResponseEntity<CommentResponseDto.CommentListResponseDto> createComment(@RequestBody CreateCommentRequestDto createCommentRequestDto, @AuthUserId String userId) {
+    public ResponseEntity<CommentListResponseDto.CommentResponseDto> createComment(@RequestBody CreateCommentRequestDto createCommentRequestDto, @AuthUserId String userId) {
         Comment comment = commentMapper.createCommentRequestDtoToComment(createCommentRequestDto, userId);
         Comment createdComment = commentService.createComment(comment, userId);
-        CommentResponseDto.CommentListResponseDto response = commentMapper.commentToCommentListResponseDto(createdComment);
+        CommentListResponseDto.CommentResponseDto response = commentMapper.commentToCommentListResponseDto(createdComment);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -70,7 +60,7 @@ public class CommentController {
     }
 
     @PutMapping("/{commentId}")
-    public ResponseEntity<CommentResponseDto.CommentListResponseDto> updateComment(
+    public ResponseEntity<CommentListResponseDto.CommentResponseDto> updateComment(
             @PathVariable Long commentId,
             @RequestBody CreateCommentRequestDto createCommentRequest,
             @AuthUserId String userId) {
@@ -88,16 +78,16 @@ public class CommentController {
 
     // 나의 댓글
     @GetMapping("/my-comments")
-    public ResponseEntity<PostResponseDto> getMyCommentedPosts(
+    public ResponseEntity<PostListResponseDto> getMyCommentedPosts(
             @AuthUserId String userId,
             Pageable pageable,
             @RequestParam(defaultValue = "NEWEST_FIRST") SortOption sortOption) {
-        Page<PostResponseDto.PostListResponseDto> posts = commentService.getMyCommentedPosts(userId, pageable, sortOption);
-        List<PostResponseDto.PostListResponseDto> postList = posts.getContent();
+        Page<PostListResponseDto.PostResponseDto> posts = commentService.getMyCommentedPosts(userId, pageable, sortOption);
+        List<PostListResponseDto.PostResponseDto> postList = posts.getContent();
 
         PagingResponse pagingResponse = PagingResponse.from(posts);
 
-        PostResponseDto response = PostResponseDto.builder()
+        PostListResponseDto response = PostListResponseDto.builder()
                 .postList(postList)
                 .paging(pagingResponse)
                 .build();
@@ -106,7 +96,7 @@ public class CommentController {
     }
     // 글별 댓글 모아보기
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<CommentResponseDto> getCommentsByPost(
+    public ResponseEntity<CommentListResponseDto> getCommentsByPost(
             @PathVariable Long postId,
             Pageable pageable,
             @RequestParam(required = false) SortOption sortOption) {
@@ -116,13 +106,13 @@ public class CommentController {
         }
 
         Page<Comment> comments = commentService.getCommentsByPost(postId, pageable, sortOption);
-        List<CommentResponseDto.CommentListResponseDto> commentList = comments.getContent().stream()
+        List<CommentListResponseDto.CommentResponseDto> commentList = comments.getContent().stream()
                 .map(commentMapper::commentToCommentListResponseDto)
                 .collect(Collectors.toList());
 
         PagingResponse pagingResponse = PagingResponse.from(comments);
 
-        CommentResponseDto response = CommentResponseDto.builder()
+        CommentListResponseDto response = CommentListResponseDto.builder()
                 .commentList(commentList)
                 .paging(pagingResponse)
                 .build();

--- a/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
@@ -9,8 +9,8 @@ import com.project.foradhd.domain.board.persistence.entity.PostScrapFilter;
 import com.project.foradhd.domain.board.persistence.enums.Category;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import com.project.foradhd.domain.board.web.dto.request.PostRequestDto;
+import com.project.foradhd.domain.board.web.dto.response.PostListResponseDto;
 import com.project.foradhd.domain.board.web.dto.response.PostRankingResponseDto;
-import com.project.foradhd.domain.board.web.dto.response.PostResponseDto;
 import com.project.foradhd.domain.board.web.dto.response.PostScrapFilterResponseDto;
 import com.project.foradhd.domain.board.web.dto.response.PostSearchResponseDto;
 import com.project.foradhd.domain.board.web.mapper.PostMapper;
@@ -41,17 +41,18 @@ public class PostController {
     private final PostSearchHistoryService searchHistoryService;
     private final UserService userService;
 
+    //TODO
     // 게시글 개별 조회 api
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponseDto.PostListResponseDto> getPost(@PathVariable Long postId) {
+    public ResponseEntity<PostListResponseDto.PostResponseDto> getPost(@PathVariable Long postId) {
         Post post = postService.getPost(postId);
-        PostResponseDto.PostListResponseDto response = postMapper.toPostListResponseDto(post, userService);
+        PostListResponseDto.PostResponseDto response = postMapper.toPostListResponseDto(post, userService);
         return ResponseEntity.ok(response);
     }
 
     // 게시글 작성 api
     @PostMapping
-    public ResponseEntity<PostResponseDto.PostListResponseDto> createPost(@RequestBody PostRequestDto postRequestDto, @AuthUserId String userId) {
+    public ResponseEntity<PostListResponseDto.PostResponseDto> createPost(@RequestBody PostRequestDto postRequestDto, @AuthUserId String userId) {
         Post post = postMapper.toEntity(postRequestDto, userId, userService);
         Post createdPost = postService.createPost(post);
         return ResponseEntity.status(HttpStatus.CREATED).body(postMapper.toPostListResponseDto(createdPost, userService));
@@ -59,7 +60,7 @@ public class PostController {
 
     // 게시글 수정 api
     @PutMapping("/{postId}")
-    public ResponseEntity<PostResponseDto.PostListResponseDto> updatePost(@PathVariable Long postId, @RequestBody PostRequestDto postRequestDto) {
+    public ResponseEntity<PostListResponseDto.PostResponseDto> updatePost(@PathVariable Long postId, @RequestBody PostRequestDto postRequestDto) {
         Post existingPost = postService.getPost(postId);
         Post updatedPost = Post.builder()
                 .id(existingPost.getId())
@@ -86,17 +87,18 @@ public class PostController {
         return ResponseEntity.noContent().build();
     }
 
+    //TODO
     // 전체 게시글 조회 api
     @GetMapping("/all")
-    public ResponseEntity<PostResponseDto> getAllPosts(Pageable pageable) {
+    public ResponseEntity<PostListResponseDto> getAllPosts(Pageable pageable) {
         Page<Post> postPage = postService.getAllPosts(pageable);
-        List<PostResponseDto.PostListResponseDto> postResponseDtoList = postPage.getContent().stream()
+        List<PostListResponseDto.PostResponseDto> postResponseDtoList = postPage.getContent().stream()
                 .map(post -> postMapper.toPostListResponseDto(post, userService))
                 .collect(Collectors.toList());
 
         PagingResponse pagingResponse = PagingResponse.from(postPage);
 
-        PostResponseDto response = PostResponseDto.builder()
+        PostListResponseDto response = PostListResponseDto.builder()
                 .postList(postResponseDtoList)
                 .paging(pagingResponse)
                 .build();
@@ -104,19 +106,20 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //TODO
     // 카테고리별 게시글 조회 api
     @GetMapping("/category")
-    public ResponseEntity<PostResponseDto> getPostsByCategory(
+    public ResponseEntity<PostListResponseDto> getPostsByCategory(
             @RequestParam("category") Category category,
             Pageable pageable) {
         Page<Post> postPage = postService.listByCategory(category, pageable);
-        List<PostResponseDto.PostListResponseDto> postResponseDtoList = postPage.getContent().stream()
+        List<PostListResponseDto.PostResponseDto> postResponseDtoList = postPage.getContent().stream()
                 .map(post -> postMapper.toPostListResponseDto(post, userService))
                 .collect(Collectors.toList());
 
         PagingResponse pagingResponse = PagingResponse.from(postPage);
 
-        PostResponseDto response = PostResponseDto.builder()
+        PostListResponseDto response = PostListResponseDto.builder()
                 .postList(postResponseDtoList)
                 .paging(pagingResponse)
                 .build();
@@ -124,17 +127,18 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //TODO
     // 내가 작성한 게시글 조회 api
     @GetMapping("/my-posts")
-    public ResponseEntity<PostResponseDto> getUserPostsByCategory(@AuthUserId String userId, @RequestParam Category category, Pageable pageable, @RequestParam SortOption sortOption) {
+    public ResponseEntity<PostListResponseDto> getUserPostsByCategory(@AuthUserId String userId, @RequestParam Category category, Pageable pageable, @RequestParam SortOption sortOption) {
         Page<Post> userPosts = postService.getUserPostsByCategory(userId, category, pageable, sortOption);
-        List<PostResponseDto.PostListResponseDto> postResponseDtoList = userPosts.getContent().stream()
+        List<PostListResponseDto.PostResponseDto> postResponseDtoList = userPosts.getContent().stream()
                 .map(post -> postMapper.toPostListResponseDto(post, userService))
                 .collect(Collectors.toList());
 
         PagingResponse pagingResponse = PagingResponse.from(userPosts);
 
-        PostResponseDto response = PostResponseDto.builder()
+        PostListResponseDto response = PostListResponseDto.builder()
                 .postList(postResponseDtoList)
                 .paging(pagingResponse)
                 .build();
@@ -142,6 +146,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //TODO
     // 내가 스크랩한 게시글 조회 api
     @GetMapping("/scraps")
     public ResponseEntity<PostScrapFilterResponseDto> getScrapsByUserAndCategory(
@@ -178,17 +183,18 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
+    //TODO
     // 내가 좋아요한 게시글 조회 api
     @GetMapping("/liked")
-    public ResponseEntity<PostResponseDto> getLikedPostsByUser(@AuthUserId String userId, Pageable pageable) {
+    public ResponseEntity<PostListResponseDto> getLikedPostsByUser(@AuthUserId String userId, Pageable pageable) {
         Page<Post> likedPosts = postLikeFilterService.getLikedPostsByUser(userId, pageable);
-        List<PostResponseDto.PostListResponseDto> postResponseDtoList = likedPosts.getContent().stream()
+        List<PostListResponseDto.PostResponseDto> postResponseDtoList = likedPosts.getContent().stream()
                 .map(post -> postMapper.toPostListResponseDto(post, userService))
                 .collect(Collectors.toList());
 
         PagingResponse pagingResponse = PagingResponse.from(likedPosts);
 
-        PostResponseDto response = PostResponseDto.builder()
+        PostListResponseDto response = PostListResponseDto.builder()
                 .postList(postResponseDtoList)
                 .paging(pagingResponse)
                 .build();
@@ -196,6 +202,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //TODO
     // 메인홈 - 실시간 랭킹
     @GetMapping("/main/top")
     public ResponseEntity<PostRankingResponseDto.PagedPostRankingResponseDto> getTopPosts(Pageable pageable) {
@@ -216,6 +223,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //TODO
     // 메인홈 - 카테고리별 실시간 랭킹
     @GetMapping("/main/top/category")
     public ResponseEntity<PostRankingResponseDto.PagedPostRankingResponseDto> getTopPostsByCategory(
@@ -238,6 +246,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    //TODO
     // 게시글 검색 api
     @GetMapping("/search")
     public ResponseEntity<PostSearchResponseDto> searchPostsByTitle(

--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/CommentListResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/CommentListResponseDto.java
@@ -1,26 +1,23 @@
 package com.project.foradhd.domain.board.web.dto.response;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.project.foradhd.domain.board.persistence.entity.Comment;
 import com.project.foradhd.global.paging.web.dto.response.PagingResponse;
 import com.project.foradhd.global.serializer.LocalDateTimeToEpochSecondSerializer;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 @Getter
 @Builder(toBuilder = true)
-public class CommentResponseDto {
+public class CommentListResponseDto {
 
-    private List<CommentListResponseDto> commentList;
+    private List<CommentResponseDto> commentList;
     private PagingResponse paging;
 
     @Getter
     @Builder
-    public static class CommentListResponseDto {
+    public static class CommentResponseDto {
         private final Long id;
         private final String content;
         private final String userId;
@@ -34,7 +31,7 @@ public class CommentResponseDto {
         private LocalDateTime lastModifiedAt;
 
         private final Long parentCommentId;
-        private final List<CommentResponseDto.CommentListResponseDto> children;
+        private final List<CommentResponseDto> children;
         private final String nickname;
         private final String profileImage;
     }

--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/CommentListResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/CommentListResponseDto.java
@@ -34,5 +34,6 @@ public class CommentListResponseDto {
         private final List<CommentResponseDto> children;
         private final String nickname;
         private final String profileImage;
+        private Boolean isBlocked;
     }
 }

--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostListResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostListResponseDto.java
@@ -40,6 +40,7 @@ public class PostListResponseDto {
         private List<CommentListResponseDto.CommentResponseDto> comments;
         private String nickname;
         private String profileImage;
+        private Boolean isBlocked;
 
         @JsonSerialize(using = LocalDateTimeToEpochSecondSerializer.class)
         private LocalDateTime createdAt;

--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostListResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostListResponseDto.java
@@ -16,16 +16,16 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PostResponseDto {
+public class PostListResponseDto {
 
-    private List<PostListResponseDto> postList;
+    private List<PostResponseDto> postList;
     private PagingResponse paging;
 
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PostListResponseDto {
+    public static class PostResponseDto {
         private Long id;
         private String userId;
         private String title;
@@ -37,7 +37,7 @@ public class PostResponseDto {
         private long scrapCount;
         private long viewCount;
         private Category category;
-        private List<CommentResponseDto.CommentListResponseDto> comments;
+        private List<CommentListResponseDto.CommentResponseDto> comments;
         private String nickname;
         private String profileImage;
 

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/CommentMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/CommentMapper.java
@@ -3,7 +3,7 @@ package com.project.foradhd.domain.board.web.mapper;
 import com.project.foradhd.domain.board.persistence.entity.Comment;
 import com.project.foradhd.domain.board.persistence.entity.Post;
 import com.project.foradhd.domain.board.web.dto.request.CreateCommentRequestDto;
-import com.project.foradhd.domain.board.web.dto.response.CommentResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.CommentListResponseDto;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserProfile;
 import com.project.foradhd.domain.user.persistence.repository.UserProfileRepository;
@@ -43,13 +43,13 @@ public interface CommentMapper {
     @Mapping(source = "user.id", target = "userId")
     @Mapping(source = "parentComment.id", target = "parentCommentId")
     @Mapping(source = "childComments", target = "children", qualifiedByName = "mapChildComments")
-    CommentResponseDto.CommentListResponseDto commentToCommentListResponseDto(Comment comment);
+    CommentListResponseDto.CommentResponseDto commentToCommentListResponseDto(Comment comment);
 
-    default CommentResponseDto.CommentListResponseDto commentToCommentListResponseDtoWithChildren(Comment comment) {
+    default CommentListResponseDto.CommentResponseDto commentToCommentListResponseDtoWithChildren(Comment comment) {
         if (comment.getParentComment() != null) { // 자식 댓글인 경우
             return commentToCommentListResponseDto(comment);
         } else { // 부모 댓글인 경우
-            return CommentResponseDto.CommentListResponseDto.builder()
+            return CommentListResponseDto.CommentResponseDto.builder()
                     .id(comment.getId())
                     .content(comment.getContent())
                     .userId(comment.getUser().getId())
@@ -68,11 +68,11 @@ public interface CommentMapper {
         }
     }
 
-    default CommentResponseDto toResponseDto(List<Comment> comments, PagingResponse paging) {
-        List<CommentResponseDto.CommentListResponseDto> commentList = comments.stream()
+    default CommentListResponseDto toResponseDto(List<Comment> comments, PagingResponse paging) {
+        List<CommentListResponseDto.CommentResponseDto> commentList = comments.stream()
                 .map(this::commentToCommentListResponseDtoWithChildren)
                 .collect(Collectors.toList());
-        return CommentResponseDto.builder()
+        return CommentListResponseDto.builder()
                 .commentList(commentList)
                 .paging(paging)
                 .build();
@@ -103,7 +103,7 @@ public interface CommentMapper {
     }
 
     @Named("mapChildComments")
-    default List<CommentResponseDto.CommentListResponseDto> mapChildComments(List<Comment> childComments) {
+    default List<CommentListResponseDto.CommentResponseDto> mapChildComments(List<Comment> childComments) {
         if (childComments == null) {
             return null;
         }

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
@@ -4,9 +4,9 @@ import com.project.foradhd.domain.board.persistence.entity.Comment;
 import com.project.foradhd.domain.board.persistence.entity.Post;
 import com.project.foradhd.domain.board.web.dto.PostDto;
 import com.project.foradhd.domain.board.web.dto.request.PostRequestDto;
-import com.project.foradhd.domain.board.web.dto.response.CommentResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.CommentListResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.PostListResponseDto;
 import com.project.foradhd.domain.board.web.dto.response.PostRankingResponseDto;
-import com.project.foradhd.domain.board.web.dto.response.PostResponseDto;
 import com.project.foradhd.domain.board.web.dto.response.PostSearchResponseDto;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.persistence.entity.User;
@@ -63,7 +63,7 @@ public interface PostMapper {
     @Mapping(source = "user.id", target = "userId")
     @Mapping(source = "nickname", target = "nickname")
     @Mapping(source = "profileImage", target = "profileImage")
-    PostResponseDto.PostListResponseDto toPostListResponseDto(Post post, @Context UserService userService);
+    PostListResponseDto.PostResponseDto toPostListResponseDto(Post post, @Context UserService userService);
 
     @AfterMapping
     default void setUsers(@MappingTarget Post.PostBuilder postBuilder, @Context String userId, @Context UserService userService) {
@@ -80,7 +80,7 @@ public interface PostMapper {
     }
 
     @AfterMapping
-    default void setAnonymousOrUserProfile(@MappingTarget PostResponseDto.PostListResponseDto.PostListResponseDtoBuilder dto, Post post, @Context UserService userService) {
+    default void setAnonymousOrUserProfile(@MappingTarget PostListResponseDto.PostResponseDto.PostResponseDtoBuilder dto, Post post, @Context UserService userService) {
         if (post.getAnonymous()) {
             dto.nickname("익명");
             dto.profileImage("image/default-profile.png");
@@ -93,7 +93,7 @@ public interface PostMapper {
         }
     }
 
-    default List<CommentResponseDto.CommentListResponseDto> mapCommentList(List<Comment> comments) {
+    default List<CommentListResponseDto.CommentResponseDto> mapCommentList(List<Comment> comments) {
         if (comments == null) return null;
         CommentMapper commentMapper = Mappers.getMapper(CommentMapper.class);
         return comments.stream()

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
@@ -29,7 +29,7 @@ public interface UserService {
 
     User snsSignUp(String userId, SnsSignUpData snsSignUpData);
 
-    void blockUser(String userId, String blockedUserId, Boolean blocked);
+    void blockUser(String userId, String blockedUserId, Boolean isBlocked);
 
     void updateProfile(String userId, ProfileUpdateData profileUpdateData);
 

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
@@ -7,11 +7,7 @@ import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
 import com.project.foradhd.domain.user.business.dto.out.UserProfileDetailsData;
-import com.project.foradhd.domain.user.persistence.entity.User;
-import com.project.foradhd.domain.user.persistence.entity.UserPrivacy;
-import com.project.foradhd.domain.user.persistence.entity.UserProfile;
-import com.project.foradhd.domain.user.persistence.entity.UserPushNotificationApproval;
-import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
+import com.project.foradhd.domain.user.persistence.entity.*;
 import com.project.foradhd.domain.user.persistence.enums.Provider;
 
 import java.util.List;
@@ -30,6 +26,10 @@ public interface UserService {
     User snsSignUp(String userId, SnsSignUpData snsSignUpData);
 
     void blockUser(String userId, String blockedUserId, Boolean isBlocked);
+
+    List<UserBlocked> getUserBlockedList(String userId);
+
+    List<String> getBlockedUserIdList(String userId);
 
     void updateProfile(String userId, ProfileUpdateData profileUpdateData);
 

--- a/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/UserService.java
@@ -29,6 +29,8 @@ public interface UserService {
 
     User snsSignUp(String userId, SnsSignUpData snsSignUpData);
 
+    void blockUser(String userId, String blockedUserId, Boolean blocked);
+
     void updateProfile(String userId, ProfileUpdateData profileUpdateData);
 
     void updatePassword(String userId, PasswordUpdateData passwordUpdateData);

--- a/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
@@ -96,17 +96,17 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void blockUser(String userId, String blockedUserId, Boolean blocked) {
+    public void blockUser(String userId, String blockedUserId, Boolean isBlocked) {
         User user = getUser(userId);
         User blockedUser = getUser(blockedUserId);
         userBlockedRepository.findByUserIdAndBlockedUserId(userId, blockedUserId)
                 .ifPresentOrElse(
-                        userBlocked -> userBlocked.updateBlocked(blocked),
+                        userBlocked -> userBlocked.updateIsBlocked(isBlocked),
                         () -> {
                             UserBlocked userBlocked = UserBlocked.builder()
                                     .user(user)
                                     .blockedUser(blockedUser)
-                                    .deleted(!blocked)
+                                    .deleted(!isBlocked)
                                     .build();
                             userBlockedRepository.save(userBlocked);
                         });

--- a/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
@@ -26,6 +26,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final UserPrivacyRepository userPrivacyRepository;
     private final UserProfileRepository userProfileRepository;
+    private final UserBlockedRepository userBlockedRepository;
     private final TermsRepository termsRepository;
     private final UserTermsApprovalRepository userTermsApprovalRepository;
     private final PushNotificationApprovalRepository pushNotificationApprovalRepository;
@@ -91,6 +92,24 @@ public class UserServiceImpl implements UserService {
         userTermsApprovalRepository.saveAll(userTermsApprovals);
         userPushNotificationApprovalRepository.saveAll(userPushNotificationApprovals);
         return user;
+    }
+
+    @Override
+    @Transactional
+    public void blockUser(String userId, String blockedUserId, Boolean blocked) {
+        User user = getUser(userId);
+        User blockedUser = getUser(blockedUserId);
+        userBlockedRepository.findByUserIdAndBlockedUserId(userId, blockedUserId)
+                .ifPresentOrElse(
+                        userBlocked -> userBlocked.updateBlocked(blocked),
+                        () -> {
+                            UserBlocked userBlocked = UserBlocked.builder()
+                                    .user(user)
+                                    .blockedUser(blockedUser)
+                                    .deleted(!blocked)
+                                    .build();
+                            userBlockedRepository.save(userBlocked);
+                        });
     }
 
     @Override

--- a/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
@@ -113,6 +113,18 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public List<UserBlocked> getUserBlockedList(String userId) {
+        return userBlockedRepository.findByUserId(userId);
+    }
+
+    @Override
+    public List<String> getBlockedUserIdList(String userId) {
+        return getUserBlockedList(userId).stream()
+                .map(userBlocked -> userBlocked.getBlockedUser().getId())
+                .toList();
+    }
+
+    @Override
     @Transactional
     public void updateProfile(String userId, ProfileUpdateData profileUpdateData) {
         UserProfile newUserProfile = profileUpdateData.getUserProfile();

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
@@ -9,6 +9,8 @@ import org.hibernate.annotations.ColumnDefault;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(name = "user_and_blocked_user_unique",
+        columnNames = {"user_id", "blocked_user_id"}))
 @Entity
 public class UserBlocked extends BaseTimeEntity {
 

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
@@ -1,0 +1,32 @@
+package com.project.foradhd.domain.user.persistence.entity;
+
+import com.project.foradhd.global.audit.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserBlocked extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_blocked_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_user_id", nullable = false)
+    private User blockedUser;
+
+    @Builder.Default
+    @ColumnDefault("0")
+    @Column(nullable = false)
+    private Boolean deleted = Boolean.FALSE;
+}

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
@@ -31,4 +31,8 @@ public class UserBlocked extends BaseTimeEntity {
     @ColumnDefault("0")
     @Column(nullable = false)
     private Boolean deleted = Boolean.FALSE;
+
+    public void updateBlocked(boolean blocked) {
+        this.deleted = !blocked;
+    }
 }

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserBlocked.java
@@ -32,7 +32,7 @@ public class UserBlocked extends BaseTimeEntity {
     @Column(nullable = false)
     private Boolean deleted = Boolean.FALSE;
 
-    public void updateBlocked(boolean blocked) {
-        this.deleted = !blocked;
+    public void updateIsBlocked(boolean isBlocked) {
+        this.deleted = !isBlocked;
     }
 }

--- a/src/main/java/com/project/foradhd/domain/user/persistence/repository/UserBlockedRepository.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/repository/UserBlockedRepository.java
@@ -1,0 +1,11 @@
+package com.project.foradhd.domain.user.persistence.repository;
+
+import com.project.foradhd.domain.user.persistence.entity.UserBlocked;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserBlockedRepository extends JpaRepository<UserBlocked, Long> {
+
+    Optional<UserBlocked> findByUserIdAndBlockedUserId(String userId, String blockedUserId);
+}

--- a/src/main/java/com/project/foradhd/domain/user/persistence/repository/UserBlockedRepository.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/repository/UserBlockedRepository.java
@@ -3,9 +3,12 @@ package com.project.foradhd.domain.user.persistence.repository;
 import com.project.foradhd.domain.user.persistence.entity.UserBlocked;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserBlockedRepository extends JpaRepository<UserBlocked, Long> {
 
     Optional<UserBlocked> findByUserIdAndBlockedUserId(String userId, String blockedUserId);
+
+    List<UserBlocked> findByUserId(String userId);
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -79,7 +79,7 @@ public class UserController {
 
     @PostMapping("/block")
     public ResponseEntity<Void> blockUser(@AuthUserId String userId, @RequestBody @Valid UserBlockRequest request) {
-        userService.blockUser(userId, request.getBlockedUserId(), request.getBlocked());
+        userService.blockUser(userId, request.getBlockedUserId(), request.getIsBlocked());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -78,8 +78,7 @@ public class UserController {
     }
 
     @PostMapping("/block")
-    public ResponseEntity<Void> blockUser(@AuthUserId String userId,
-                                        @RequestBody @Valid UserBlockRequest request) {
+    public ResponseEntity<Void> blockUser(@AuthUserId String userId, @RequestBody @Valid UserBlockRequest request) {
         userService.blockUser(userId, request.getBlockedUserId(), request.getBlocked());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/controller/UserController.java
@@ -77,6 +77,13 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/block")
+    public ResponseEntity<Void> blockUser(@AuthUserId String userId,
+                                        @RequestBody @Valid UserBlockRequest request) {
+        userService.blockUser(userId, request.getBlockedUserId(), request.getBlocked());
+        return ResponseEntity.ok().build();
+    }
+
     @PutMapping("/email-auth")
     public ResponseEntity<EmailAuthValidationResponse> validateEmailAuth(@AuthUserId String userId,
                                                                 @RequestBody @Valid EmailAuthValidationRequest request) {

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/UserBlockRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/UserBlockRequest.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 public class UserBlockRequest {
 
     private String blockedUserId;
-    private Boolean blocked;
+    private Boolean isBlocked;
 }

--- a/src/main/java/com/project/foradhd/domain/user/web/dto/request/UserBlockRequest.java
+++ b/src/main/java/com/project/foradhd/domain/user/web/dto/request/UserBlockRequest.java
@@ -1,0 +1,14 @@
+package com.project.foradhd.domain.user.web.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserBlockRequest {
+
+    private String blockedUserId;
+    private Boolean blocked;
+}

--- a/src/main/java/com/project/foradhd/global/exception/ErrorCode.java
+++ b/src/main/java/com/project/foradhd/global/exception/ErrorCode.java
@@ -60,7 +60,7 @@ public enum ErrorCode {
     SYSTEM_ERROR(INTERNAL_SERVER_ERROR, "시스템 에러입니다."),
 
     //board
-    BOARD_NOT_FOUND(NOT_FOUND, "존재하지 않는 게시물입니다."),
+    NOT_FOUND_POST(NOT_FOUND, "존재하지 않는 게시글입니다."),
     ACCESS_DENIED(FORBIDDEN, "접근 권한이 없습니다."),
 
     //comment

--- a/src/test/java/com/project/foradhd/domain/board/business/service/CommentServiceImplTest.java
+++ b/src/test/java/com/project/foradhd/domain/board/business/service/CommentServiceImplTest.java
@@ -18,7 +18,7 @@ import com.project.foradhd.domain.board.persistence.entity.Post;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import com.project.foradhd.domain.board.persistence.repository.CommentLikeFilterRepository;
 import com.project.foradhd.domain.board.persistence.repository.CommentRepository;
-import com.project.foradhd.domain.board.web.dto.response.PostResponseDto;
+import com.project.foradhd.domain.board.web.dto.response.PostListResponseDto;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.fixtures.UserFixtures;
 import com.project.foradhd.domain.user.persistence.entity.User;
@@ -149,7 +149,7 @@ class CommentServiceImplTest {
         given(commentRepository.findByUserId(eq(user.getId()), any(Pageable.class))).willReturn(commentPage);
 
         //when
-        Page<PostResponseDto.PostListResponseDto> result = commentService.getMyCommentedPosts(user.getId(), pageable, SortOption.NEWEST_FIRST);
+        Page<PostListResponseDto.PostResponseDto> result = commentService.getMyCommentedPosts(user.getId(), pageable, SortOption.NEWEST_FIRST);
 
         //then
         assertThat(result).isNotNull();

--- a/src/test/java/com/project/foradhd/domain/user/business/service/UserServiceTest.java
+++ b/src/test/java/com/project/foradhd/domain/user/business/service/UserServiceTest.java
@@ -239,7 +239,7 @@ class UserServiceTest {
         //given
         String userId = "userId";
         String blockedUserId = "blockedUserId";
-        boolean blocked = true;
+        boolean isBlocked = true;
         User user = toUser().id(userId).build();
         User blockedUser = toUser().id(blockedUserId).build();
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -247,14 +247,14 @@ class UserServiceTest {
         given(userBlockedRepository.findByUserIdAndBlockedUserId(userId, blockedUserId)).willReturn(Optional.empty());
 
         //when
-        userService.blockUser(userId, blockedUserId, blocked);
+        userService.blockUser(userId, blockedUserId, isBlocked);
 
         //then
         then(userBlockedRepository).should(times(1)).save(userBlockedArgumentCaptor.capture());
         UserBlocked userBlocked = userBlockedArgumentCaptor.getValue();
         assertThat(userBlocked.getUser()).isEqualTo(user);
         assertThat(userBlocked.getBlockedUser()).isEqualTo(blockedUser);
-        assertThat(userBlocked.getDeleted()).isEqualTo(!blocked);
+        assertThat(userBlocked.getDeleted()).isEqualTo(!isBlocked);
     }
 
     @DisplayName("유저 차단 테스트 - 성공: 기존 차단 내역 있는 경우")
@@ -263,7 +263,7 @@ class UserServiceTest {
         //given
         String userId = "userId";
         String blockedUserId = "blockedUserId";
-        boolean blocked = true;
+        boolean isBlocked = true;
         User user = toUser().id(userId).build();
         User blockedUser = toUser().id(blockedUserId).build();
         UserBlocked userBlocked = UserBlocked.builder()
@@ -275,10 +275,10 @@ class UserServiceTest {
         given(userBlockedRepository.findByUserIdAndBlockedUserId(userId, blockedUserId)).willReturn(Optional.of(userBlocked));
 
         //when
-        userService.blockUser(userId, blockedUserId, blocked);
+        userService.blockUser(userId, blockedUserId, isBlocked);
 
         //then
-        assertThat(userBlocked.getDeleted()).isEqualTo(!blocked);
+        assertThat(userBlocked.getDeleted()).isEqualTo(!isBlocked);
     }
 
     @DisplayName("프로필 수정 테스트")

--- a/src/test/java/com/project/foradhd/domain/user/business/service/UserServiceTest.java
+++ b/src/test/java/com/project/foradhd/domain/user/business/service/UserServiceTest.java
@@ -23,14 +23,8 @@ import com.project.foradhd.domain.user.business.dto.in.SignUpData;
 import com.project.foradhd.domain.user.business.dto.in.SnsSignUpData;
 import com.project.foradhd.domain.user.business.dto.in.TermsApprovalsUpdateData;
 import com.project.foradhd.domain.user.business.service.impl.UserServiceImpl;
-import com.project.foradhd.domain.user.persistence.entity.PushNotificationApproval;
-import com.project.foradhd.domain.user.persistence.entity.Terms;
-import com.project.foradhd.domain.user.persistence.entity.User;
-import com.project.foradhd.domain.user.persistence.entity.UserPrivacy;
-import com.project.foradhd.domain.user.persistence.entity.UserProfile;
-import com.project.foradhd.domain.user.persistence.entity.UserPushNotificationApproval;
+import com.project.foradhd.domain.user.persistence.entity.*;
 import com.project.foradhd.domain.user.persistence.entity.UserPushNotificationApproval.UserPushNotificationApprovalId;
-import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval;
 import com.project.foradhd.domain.user.persistence.entity.UserTermsApproval.UserTermsApprovalId;
 import com.project.foradhd.domain.user.persistence.enums.ForAdhdType;
 import com.project.foradhd.domain.user.persistence.enums.Gender;
@@ -45,6 +39,8 @@ import com.project.foradhd.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -66,6 +62,9 @@ class UserServiceTest {
     UserProfileRepository userProfileRepository;
 
     @Mock
+    UserBlockedRepository userBlockedRepository;
+
+    @Mock
     TermsRepository termsRepository;
 
     @Mock
@@ -82,6 +81,9 @@ class UserServiceTest {
 
     @Mock
     UserAuthInfoService userAuthInfoService;
+
+    @Captor
+    ArgumentCaptor<UserBlocked> userBlockedArgumentCaptor;
 
     @DisplayName("유저 닉네임 중복 여부 확인 로직 테스트")
     @Test
@@ -229,6 +231,54 @@ class UserServiceTest {
         then(userProfileRepository).should(times(1)).save(newUserProfile);
         then(userTermsApprovalRepository).should(times(1)).saveAll(newUserTermsApprovals);
         then(userPushNotificationApprovalRepository).should(times(1)).saveAll(newUserPushNotificationApprovals);
+    }
+
+    @DisplayName("유저 차단 테스트 - 성공: 기존 차단 내역 없는 경우")
+    @Test
+    void block_user_not_exists() {
+        //given
+        String userId = "userId";
+        String blockedUserId = "blockedUserId";
+        boolean blocked = true;
+        User user = toUser().id(userId).build();
+        User blockedUser = toUser().id(blockedUserId).build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.findById(blockedUserId)).willReturn(Optional.of(blockedUser));
+        given(userBlockedRepository.findByUserIdAndBlockedUserId(userId, blockedUserId)).willReturn(Optional.empty());
+
+        //when
+        userService.blockUser(userId, blockedUserId, blocked);
+
+        //then
+        then(userBlockedRepository).should(times(1)).save(userBlockedArgumentCaptor.capture());
+        UserBlocked userBlocked = userBlockedArgumentCaptor.getValue();
+        assertThat(userBlocked.getUser()).isEqualTo(user);
+        assertThat(userBlocked.getBlockedUser()).isEqualTo(blockedUser);
+        assertThat(userBlocked.getDeleted()).isEqualTo(!blocked);
+    }
+
+    @DisplayName("유저 차단 테스트 - 성공: 기존 차단 내역 있는 경우")
+    @Test
+    void block_user_exists() {
+        //given
+        String userId = "userId";
+        String blockedUserId = "blockedUserId";
+        boolean blocked = true;
+        User user = toUser().id(userId).build();
+        User blockedUser = toUser().id(blockedUserId).build();
+        UserBlocked userBlocked = UserBlocked.builder()
+                .user(user)
+                .blockedUser(blockedUser)
+                .build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.findById(blockedUserId)).willReturn(Optional.of(blockedUser));
+        given(userBlockedRepository.findByUserIdAndBlockedUserId(userId, blockedUserId)).willReturn(Optional.of(userBlocked));
+
+        //when
+        userService.blockUser(userId, blockedUserId, blocked);
+
+        //then
+        assertThat(userBlocked.getDeleted()).isEqualTo(!blocked);
     }
 
     @DisplayName("프로필 수정 테스트")


### PR DESCRIPTION
## 💻 구현 내용 

- 게시글, 댓글 작성자를 차단할 수 있는 기능을 구현하였습니다. 
- 차단 시 해당 작성자의 모든 게시글, 댓글 내용 가림 처림 ex. "차단한 멤버가 작성한 게시글(혹은 댓글)입니다."
- 멤버 차단 횟수 제한 없음
- 차단 해제 기능 없음
- 차단한 사용자 조회하는 기능 없음

## 🗣️ For 리뷰어

- 각 유저별 차단 유저와의 관계를 관리하는 `UserBlocked` 엔티티 추가하였습니다. 
- 게시글, 댓글 조회 시 해당 글이 차단한 유저가 작성한 글인지는 응답 바디로 내려주는 `isBlocked`로 판단합니다. 해당 값은 `PostMapper` 또는 `CommentMapper`의 메소드 파라미터로 전달해준 `blockedUserIdList` 리스트에 작성자 ID가 포함되는지 여부로 설정됩니다. 

close #94