### PR TITLE
fix: 댓글 레벨에서 대댓글 조회되는 문제 해결

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
@@ -143,8 +143,12 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @Transactional
     public Page<Comment> getCommentsByPost(Long postId, Pageable pageable, SortOption sortOption) {
-        pageable = applySorting(pageable, sortOption);
-        return commentRepository.findByPostId(postId, pageable);
+        return commentRepository.findRootCommentsByPostId(postId, pageable);
+    }
+
+    @Transactional
+    public List<Comment> getChildComments(Long parentCommentId) {
+        return commentRepository.findChildCommentsByParentCommentId(parentCommentId);
     }
 
     @Override

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.project.foradhd.global.exception.ErrorCode.NOT_FOUND_COMMENT;
+import static org.springframework.data.jpa.repository.query.QueryUtils.applySorting;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -143,12 +144,8 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @Transactional
     public Page<Comment> getCommentsByPost(Long postId, Pageable pageable, SortOption sortOption) {
-        return commentRepository.findRootCommentsByPostId(postId, pageable);
-    }
-
-    @Transactional
-    public List<Comment> getChildComments(Long parentCommentId) {
-        return commentRepository.findChildCommentsByParentCommentId(parentCommentId);
+        pageable = applySorting(pageable, sortOption);
+        return commentRepository.findByPostId(postId, pageable);
     }
 
     @Override

--- a/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentRepository.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentRepository.java
@@ -34,8 +34,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     long countByPostId(@Param("postId") Long postId);
 
     List<Comment> findByParentCommentId(Long parentCommentId);
-    @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :parentCommentId")
-    List<Comment> findChildCommentsByParentCommentId(@Param("parentCommentId") Long parentCommentId);
 
     long countByPostIdAndAnonymous(Long postId, boolean anonymous);
     List<Comment> findByPostIdAndUserIdAndAnonymous(Long postId, String userId, boolean anonymous);
@@ -50,4 +48,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.id = :id")
     void deleteCommentById(Long id);
+
+    @Query("SELECT c FROM Comment c WHERE c.parentComment IS NULL AND c.post.id = :postId")
+    Page<Comment> findRootCommentsByPostId(@Param("postId") Long postId, Pageable pageable);
+
+    @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :parentCommentId")
+    List<Comment> findChildCommentsByParentCommentId(@Param("parentCommentId") Long parentCommentId);
 }

--- a/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentRepository.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentRepository.java
@@ -48,10 +48,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.id = :id")
     void deleteCommentById(Long id);
-
-    @Query("SELECT c FROM Comment c WHERE c.parentComment IS NULL AND c.post.id = :postId")
-    Page<Comment> findRootCommentsByPostId(@Param("postId") Long postId, Pageable pageable);
-
-    @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :parentCommentId")
-    List<Comment> findChildCommentsByParentCommentId(@Param("parentCommentId") Long parentCommentId);
 }

--- a/src/main/java/com/project/foradhd/domain/board/web/controller/CommentController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/CommentController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -123,6 +124,7 @@ public class CommentController {
 
         return ResponseEntity.ok(response);
     }
+
 
     // 댓글 좋아요 토글
     @PostMapping("/{commentId}/like")

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/CommentMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/CommentMapper.java
@@ -50,26 +50,20 @@ public interface CommentMapper {
     }
 
     default CommentListResponseDto.CommentResponseDto commentToCommentListResponseDtoWithChildren(Comment comment, List<String> blockedUserIdList) {
-        if (comment.getParentComment() != null) { // 자식 댓글인 경우
-            return commentToCommentResponseDto(comment, blockedUserIdList);
-        } else { // 부모 댓글인 경우
-            return CommentListResponseDto.CommentResponseDto.builder()
-                    .id(comment.getId())
-                    .content(comment.getContent())
-                    .userId(comment.getUser().getId())
-                    .postId(comment.getPost().getId())
-                    .anonymous(comment.getAnonymous())
-                    .likeCount(comment.getLikeCount())
-                    .createdAt(comment.getCreatedAt())
-                    .lastModifiedAt(comment.getLastModifiedAt())
-                    .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
-                    .children(comment.getChildComments().stream()
-                            .map(childComment -> commentToCommentResponseDto(childComment, blockedUserIdList))
-                            .toList())
-                    .nickname(comment.getNickname())
-                    .profileImage(comment.getProfileImage())
-                    .build();
-        }
+        return CommentListResponseDto.CommentResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .userId(comment.getUser() != null ? comment.getUser().getId() : null)
+                .postId(comment.getPost().getId())
+                .anonymous(comment.getAnonymous())
+                .likeCount(comment.getLikeCount())
+                .createdAt(comment.getCreatedAt())
+                .lastModifiedAt(comment.getLastModifiedAt())
+                .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
+                .children(comment.getChildComments() != null ? mapChildComments(comment.getChildComments(), blockedUserIdList) : List.of())
+                .nickname(comment.getNickname())
+                .profileImage(comment.getProfileImage())
+                .build();
     }
 
     @Named("mapPost")

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
@@ -101,10 +101,14 @@ public interface PostMapper {
     default List<CommentListResponseDto.CommentResponseDto> mapCommentList(List<Comment> comments, List<String> blockedUserIdList) {
         if (comments == null) return List.of();
         CommentMapper commentMapper = Mappers.getMapper(CommentMapper.class);
+
+        // 부모 댓글만 매핑
         return comments.stream()
+                .filter(comment -> comment.getParentComment() == null) // 부모 댓글만 필터링
                 .map(comment -> commentMapper.commentToCommentResponseDto(comment, blockedUserIdList))
                 .collect(Collectors.toList());
     }
+
 
     default long calculateCommentCount(List<Comment> comments) {
         if (comments == null) return 0;


### PR DESCRIPTION
## 💻 구현 내용 

- postmapper에서 댓글과 대댓글 구분 없이 매핑하고 있어 문제가 발생하고 있음을 발견
-> postmapper에서 부모 댓글만 매핑되도록 수정하였습니다.

## 🛠️ 개발 오류 사항
-

## 🗣️ For 리뷰어

- postmapper와 commentmapper만 수정되었습니다!

close #96 