### PR TITLE
이미지 업로드 요청 헤더 content-type 인식 오류 해결

### DIFF
--- a/src/main/java/com/project/foradhd/global/image/web/controller/FileUploadController.java
+++ b/src/main/java/com/project/foradhd/global/image/web/controller/FileUploadController.java
@@ -7,7 +7,6 @@ import com.project.foradhd.global.service.FileStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -19,9 +18,8 @@ public class FileUploadController {
     private final FileStorageService fileStorageService;
 
     @PostMapping
-    public ResponseEntity<ImageUploadResponse> uploadImages(@RequestPart List<MultipartFile> imageFileList,
-                                                            @RequestPart ImageUploadRequest request) {
-        List<String> imagePathList = fileStorageService.uploadImages(request.getImagePathPrefix(), imageFileList);
+    public ResponseEntity<ImageUploadResponse> uploadImages(@ModelAttribute ImageUploadRequest request) {
+        List<String> imagePathList = fileStorageService.uploadImages(request.getImagePathPrefix(), request.getImageFileList());
         return ResponseEntity.ok(new ImageUploadResponse(imagePathList));
     }
 

--- a/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageDeleteRequest.java
+++ b/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageDeleteRequest.java
@@ -7,5 +7,5 @@ import java.util.List;
 @Getter
 public class ImageDeleteRequest {
 
-    List<String> imagePathList;
+    private List<String> imagePathList;
 }

--- a/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageUploadRequest.java
+++ b/src/main/java/com/project/foradhd/global/image/web/dto/request/ImageUploadRequest.java
@@ -2,9 +2,15 @@ package com.project.foradhd.global.image.web.dto.request;
 
 import com.project.foradhd.global.image.web.enums.ImagePathPrefix;
 import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Getter
+@Setter
 public class ImageUploadRequest {
 
-    ImagePathPrefix imagePathPrefix = ImagePathPrefix.DEFAULT_IMAGE;
+    private List<MultipartFile> imageFileList;
+    private ImagePathPrefix imagePathPrefix = ImagePathPrefix.DEFAULT_IMAGE;
 }


### PR DESCRIPTION
## 💻 구현 내용 

- 이미지 파일과 DTO를 `@RequestPart`로 각각 받는 경우 application/octet-stream으로 인식
- 이미지 파일과 이미지에 대한 데이터를 DTO 하나로 받아 multipart/form-data로 인식하도록 수정
