### PR TITLE
fix: 게시글 신고 API 신고 유형 값 받을 때 DTO를 통한 매핑으로 받을 수 있도록 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
@@ -14,6 +14,7 @@ import com.project.foradhd.domain.board.persistence.enums.HandleReport;
 import com.project.foradhd.domain.board.persistence.enums.Report;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import com.project.foradhd.domain.board.web.dto.request.PostRequestDto;
+import com.project.foradhd.domain.board.web.dto.request.ReportTypeDto;
 import com.project.foradhd.domain.board.web.dto.response.PostListResponseDto;
 import com.project.foradhd.domain.board.web.dto.response.PostRankingResponseDto;
 import com.project.foradhd.domain.board.web.dto.response.PostReportListResponseDto;
@@ -292,8 +293,8 @@ public class PostController {
     // 게시글 신고 API
     @PostMapping("/{postId}/report")
     public ResponseEntity<Void> reportPost(@PathVariable Long postId,
-                                           @RequestBody Report reportType){
-        postReportService.postReport(postId, reportType);
+                                           @RequestBody ReportTypeDto reportTypeDto){
+        postReportService.postReport(postId, reportTypeDto.getReportType());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/project/foradhd/domain/board/web/dto/request/ReportTypeDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/request/ReportTypeDto.java
@@ -1,0 +1,12 @@
+package com.project.foradhd.domain.board.web.dto.request;
+import com.project.foradhd.domain.board.persistence.enums.Report;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportTypeDto {
+    private Report reportType;  // Enum 타입
+}


### PR DESCRIPTION
## 🛠️ 개발 오류 사항

- 클라이언트에서 보낸 신고 유형 Enum 값을 서버에서 제대로 처리 못 하는 상황. -> DTO 매핑으로 올바르게 받을 수 있도록 처리

## 🗣️ For 리뷰어

- DTO 파일 생성했습니다!

close #111 