### PR TITLE
fix: 게시글 내용 불러올 때 null값으로 반환되는 오류 해결

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/business/service/dto/in/ReportPostData.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/dto/in/ReportPostData.java
@@ -1,17 +1,39 @@
 package com.project.foradhd.domain.board.business.service.dto.in;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.project.foradhd.domain.board.persistence.entity.Comment;
 import com.project.foradhd.domain.board.persistence.entity.Post;
+import com.project.foradhd.domain.board.persistence.enums.Category;
 import com.project.foradhd.domain.board.persistence.enums.Report;
+import com.project.foradhd.global.serializer.LocalDateTimeToEpochSecondSerializer;
+import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class ReportPostData {
-
-    private Post post;
-
+    private Long id;
+    private String userId;
+    private String title;
+    private String content;
+    private boolean anonymous;
+    private List<String> images;
+    private long likeCount;
+    private long commentCount;
+    private long scrapCount;
+    private long viewCount;
+    private Category category;
+    private List<Comment> comments;
+    private String nickname;
+    private String profileImage;
+    private String email;
     private HashMap<Report, Integer> reportTypeCounts;
 
+    @JsonSerialize(using = LocalDateTimeToEpochSecondSerializer.class)
+    private LocalDateTime createdAt;
+    @JsonSerialize(using = LocalDateTimeToEpochSecondSerializer.class)
+    private LocalDateTime lastModifiedAt;
 }

--- a/src/main/java/com/project/foradhd/domain/board/persistence/entity/Comment.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.project.foradhd.domain.board.persistence.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -24,10 +25,12 @@ public class Comment extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", referencedColumnName = "post_id")
+    @JsonIgnore
     private Post post; // 이 댓글이 속한 게시글 id
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    @JsonIgnore
     private User user; // 댓글 작성자 id
 
     @Column(nullable = false, columnDefinition = "longtext")
@@ -35,6 +38,7 @@ public class Comment extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_comment_id", referencedColumnName = "comment_id")
+    @JsonIgnore
     private Comment parentComment;
 
     @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
@@ -310,8 +310,24 @@ public class PostController {
             HashMap<Report, Integer> reportTypeCounts = postReportService.getReportTypeCounts(post);
             reportedPostDataList.add(
                     ReportPostData.builder()
-                            .post(post)
+                            .id(post.getId())
+                            .userId(post.getUser().getId())
+                            .title(post.getTitle())
+                            .content(post.getContent())
+                            .anonymous(post.getAnonymous())
+                            .images(post.getImages())
+                            .likeCount(post.getLikeCount())
+                            .commentCount(post.getCommentCount())
+                            .scrapCount(post.getScrapCount())
+                            .viewCount(post.getViewCount())
+                            .category(post.getCategory())
+                            .comments(post.getComments())
+                            .nickname(post.getNickname())
+                            .profileImage(post.getProfileImage())
+                            .email(post.getUser().getEmail())
                             .reportTypeCounts(reportTypeCounts)
+                            .createdAt(post.getCreatedAt())
+                            .lastModifiedAt(post.getLastModifiedAt())
                             .build());
         }
 


### PR DESCRIPTION
dquote> - PostController.java: 빌더를 사용해 게시글 정보 가져오도록 해주었습니다.

- ReportPostData.java:  매핑 처리 전에 미리 필드를 맞추는것이 나을 것 같다는 생각이 들어 PostReportResponseDto과 필드를 동일하게 해주었습니다.
- Comment.java: 해당 엔티티의 정보를 가져오면서 JPA 엔티티 간의 양방향 관계가 JSON 직렬화 될 때 발생하는 문제인 무한 재귀와 Lazy Loading된 프록시 객체 직렬화 오류를  방지하기 위해 JsonIgnore어노테이션을 추가해 해당 문제들을 해결 하였습니다.

## 🛠️ 개발 오류 사항

- 개발 시 오류가 났던 부분, 어떻게 해결하였는지 공유합니다. 해결하지 못했더라도 어떤 방법을 시도해 보았는지 공유하는 것도 좋습니다.
- 데이터를 가져오는 도중 양방향 관계가 JSON 직렬화 될 때 LazyLoading, 무한재귀 에러가 났었습니다. 양방향에 해당되는 필드들에 JsonIgnore어노테이션을 추가해서 직렬화 되지 않도록 해결해주었습니다

## 🗣️ For 리뷰어

- 적절하게 작성이 되었는지 확인해주세요!

close #117