### PR TITLE
fix: 이메일 허용 도메인 수정

### DIFF
--- a/src/main/java/com/project/foradhd/global/validation/validator/EmailDomainValidator.java
+++ b/src/main/java/com/project/foradhd/global/validation/validator/EmailDomainValidator.java
@@ -1,0 +1,28 @@
+package com.project.foradhd.global.validation.validator;
+
+import javax.naming.directory.*;
+import javax.naming.Context;
+import java.util.Hashtable;
+
+public class EmailDomainValidator {
+
+    /**
+     * 주어진 도메인이 이메일을 수신할 수 있는지 MX 레코드 조회를 통해 검증
+     */
+    public static boolean isDomainValid(String domain) {
+        try {
+            // DNS 조회를 위한 환경 설정
+            Hashtable<String, String> env = new Hashtable<>();
+            env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+
+            // DNS MX 레코드 조회
+            DirContext ctx = new InitialDirContext(env);
+            Attributes attrs = ctx.getAttributes(domain, new String[]{"MX"});
+            Attribute attr = attrs.get("MX");
+
+            return attr != null && attr.size() > 0; // MX 레코드가 존재하면 유효한 도메인
+        } catch (Exception e) {
+            return false; // 도메인이 존재하지 않거나 MX 레코드 조회 실패
+        }
+    }
+}

--- a/src/main/java/com/project/foradhd/global/validation/validator/EmailValidator.java
+++ b/src/main/java/com/project/foradhd/global/validation/validator/EmailValidator.java
@@ -20,6 +20,7 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
             "hotmail.com", "outlook.com", "facebook.com");
     private static final String EMAIL_AT_SYMBOL = "@";
     private static final String EMAIL_DOMAIN_VALIDATION_MESSAGE_CODE = "email.notSupported.domain";
+    private static final String EMAIL_FORMAT_VALIDATION_MESSAGE_CODE = "email.invalid.format";
 
     private final MessageSource validationMessageSource;
 
@@ -32,7 +33,7 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
         }
     }
 
-    @Override
+/*    @Override
     public boolean isValid(String email, ConstraintValidatorContext context) {
         if (!StringUtils.hasText(email) ||
                 !email.matches(emailRegex)) {
@@ -46,10 +47,25 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
             return false;
         }
         return true;
+    }*/
+
+    @Override
+    public boolean isValid(String email, ConstraintValidatorContext context) {
+        if (!StringUtils.hasText(email) || !email.matches(emailRegex)) {
+            setValidationMessage(context, EMAIL_FORMAT_VALIDATION_MESSAGE_CODE);
+            return false; // 이메일 형식이 올바르지 않음
+        }
+
+        return true; // 형식만 맞으면 허용
     }
 
     private String parseDomain(String email) {
-        if (!email.matches(DEFAULT_EMAIL_REGEX)) return "";
-        return email.split(EMAIL_AT_SYMBOL)[1];
+        return email.substring(email.indexOf(EMAIL_AT_SYMBOL) + 1);
+    }
+
+    private void setValidationMessage(ConstraintValidatorContext context, String messageCode) {
+        String message = validationMessageSource.getMessage(messageCode, null, Locale.KOREA);
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
     }
 }


### PR DESCRIPTION
## 💻 구현 내용 
- 이메일 중복 체크 시 특정 도메인만 허용하는 기존 검증 방식을 모든 이메일 도메인을 허용하는 방식으로 변경
- 기존에는 `VALID_EMAIL_DOMAIN` 리스트를 유지하여 일부 이메일 도메인만 허용했으나, 이를 **이메일 형식만 검증하는 방식**으로 개선
- 정규 표현식을 사용하여 이메일 형식(xxx@yyy.zz)이 올바르면 중복 체크 가능하도록 구현

## 🛠️ 개발 오류 사항
1. **MX 레코드 검증 방식 시도 → 실패**
- 이메일 도메인이 실제 존재하는지 확인하기 위해 MX 레코드 조회 방식을 검토
- Spring Boot 환경에서 서버 측에서 직접 MX 레코드 조회가 어렵고, 추가적인 네트워크 요청이 필요하여 비효율적
- 일부 학교 및 회사 이메일 (@sookmyung.ac.kr, @hy.ac.kr) 등이 **정상적으로 인식되지 않는 문제 발생**

2. 기존 도메인 제한 방식 문제
- 기존 VALID_EMAIL_DOMAIN 리스트 (naver.com, gmail.com 등) 내에서만 이메일을 허용하는 방식
- 특정 이메일 (@ac.kr, @company.com 등)이 차단되는 문제 발생
- 학교 및 기업 이메일 사용 불가

3. 최종 해결 방법: 이메일 형식 검증만 수행
✅ 모든 이메일 도메인을 허용
✅ 정규 표현식을 사용해 이메일 형식만 검증
✅ @example.com 같은 올바른 형식이면 중복 체크 가능
✅ 중복 체크의 기능만 수행하고, 회원가입 시 이메일 인증을 통해 실제 유효한 이메일인지 검증


## 🗣️ For 리뷰어
- 이메일 인증 시 도메인 필터링 없이 모든 이메일 도메인을 허용하는 방식으로 변경됨
- MX 레코드 검증을 고려했으나 Spring 환경에서 적절한 해결책이 없어 제외
- 정규 표현식을 통해 이메일 형식만 검증하도록 수정
- 추가적인 개선점이나 보완할 점이 있는지 리뷰 부탁드립니다

close #118