### PR TITLE
fix: 약 리뷰 작성 시 500 에러 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/medicine/business/service/impl/MedicineReviewServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/business/service/impl/MedicineReviewServiceImpl.java
@@ -42,19 +42,17 @@ public class MedicineReviewServiceImpl implements MedicineReviewService {
         Medicine medicine = medicineRepository.findById(request.getMedicineId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
 
-// ✅ 1. 리뷰 먼저 저장 (coMedications 없이)
         MedicineReview savedReview = medicineReviewRepository.save(
                 MedicineReview.builder()
                         .medicine(medicine)
                         .user(user)
                         .content(request.getContent())
                         .grade(request.getGrade())
-                        .images(request.getImages() != null ? request.getImages() : new ArrayList<>()) // null 방지
-                        .coMedications(new ArrayList<>()) // 빈 리스트로 초기화
+                        .images(request.getImages() != null ? request.getImages() : new ArrayList<>())
+                        .coMedications(new ArrayList<>())
                         .build()
         );
 
-// ✅ 2. coMedications 추가
         if (request.getCoMedications() != null && !request.getCoMedications().isEmpty()) {
             List<MedicineCoMedication> coMedicationEntities = new ArrayList<>();
             for (Long medicineId : request.getCoMedications()) {
@@ -62,15 +60,14 @@ public class MedicineReviewServiceImpl implements MedicineReviewService {
                         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
 
                 MedicineCoMedication coMedication = MedicineCoMedication.builder()
-                        .review(savedReview) // ✅ review_id가 존재하는 상태
+                        .review(savedReview)
                         .medicine(foundMedicine)
                         .build();
                 coMedicationEntities.add(coMedication);
             }
 
-            // ✅ 3. savedReview에 coMedications 추가 후 다시 저장
             savedReview.getCoMedications().addAll(coMedicationEntities);
-            medicineReviewRepository.save(savedReview); // ⭐️ 여기서 다시 저장
+            medicineReviewRepository.save(savedReview);
         }
 
         return savedReview;

--- a/src/main/java/com/project/foradhd/domain/medicine/business/service/impl/MedicineReviewServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/business/service/impl/MedicineReviewServiceImpl.java
@@ -3,6 +3,7 @@ package com.project.foradhd.domain.medicine.business.service.impl;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import com.project.foradhd.domain.medicine.business.service.MedicineReviewService;
 import com.project.foradhd.domain.medicine.persistence.entity.Medicine;
+import com.project.foradhd.domain.medicine.persistence.entity.MedicineCoMedication;
 import com.project.foradhd.domain.medicine.persistence.entity.MedicineReview;
 import com.project.foradhd.domain.medicine.persistence.entity.MedicineReviewLikeFilter;
 import com.project.foradhd.domain.medicine.persistence.repository.MedicineRepository;
@@ -21,6 +22,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -35,25 +39,41 @@ public class MedicineReviewServiceImpl implements MedicineReviewService {
     @Transactional
     public MedicineReview createReview(MedicineReviewRequest request, String userId) {
         User user = userService.getUser(userId);
-
         Medicine medicine = medicineRepository.findById(request.getMedicineId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
 
-        MedicineReview medicineReview = MedicineReview.builder()
-                .medicine(medicine)
-                .user(user)
-                .content(request.getContent())
-                .grade(request.getGrade())
-                .images(request.getImages())
-                .coMedications(request.getCoMedications())
-                .build();
+// ✅ 1. 리뷰 먼저 저장 (coMedications 없이)
+        MedicineReview savedReview = medicineReviewRepository.save(
+                MedicineReview.builder()
+                        .medicine(medicine)
+                        .user(user)
+                        .content(request.getContent())
+                        .grade(request.getGrade())
+                        .images(request.getImages() != null ? request.getImages() : new ArrayList<>()) // null 방지
+                        .coMedications(new ArrayList<>()) // 빈 리스트로 초기화
+                        .build()
+        );
 
-        MedicineReview savedReview = medicineReviewRepository.save(medicineReview);
+// ✅ 2. coMedications 추가
+        if (request.getCoMedications() != null && !request.getCoMedications().isEmpty()) {
+            List<MedicineCoMedication> coMedicationEntities = new ArrayList<>();
+            for (Long medicineId : request.getCoMedications()) {
+                Medicine foundMedicine = medicineRepository.findById(medicineId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
 
-        // 약의 평균 별점을 업데이트
-        updateMedicineRating(medicine);
+                MedicineCoMedication coMedication = MedicineCoMedication.builder()
+                        .review(savedReview) // ✅ review_id가 존재하는 상태
+                        .medicine(foundMedicine)
+                        .build();
+                coMedicationEntities.add(coMedication);
+            }
 
-        return savedReview; // DTO 변환 없이 엔티티를 반환
+            // ✅ 3. savedReview에 coMedications 추가 후 다시 저장
+            savedReview.getCoMedications().addAll(coMedicationEntities);
+            medicineReviewRepository.save(savedReview); // ⭐️ 여기서 다시 저장
+        }
+
+        return savedReview;
     }
 
     @Override
@@ -90,9 +110,22 @@ public class MedicineReviewServiceImpl implements MedicineReviewService {
         Medicine medicine = medicineRepository.findById(request.getMedicineId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
 
+        // ✅ 기존 coMedications 삭제 (먼저 새로운 객체를 만든 후 추가해야 lambda 문제 없음)
+        List<MedicineCoMedication> coMedications = request.getCoMedications().stream()
+                .map(medicineId -> {
+                    Medicine coMedicine = medicineRepository.findById(medicineId)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
+                    return MedicineCoMedication.builder()
+                            .review(existingReview)  // 기존 객체 사용 가능
+                            .medicine(coMedicine)
+                            .build();
+                })
+                .toList();
+
+        // ✅ 새 `updatedReview` 객체 생성 (기존 review 변경 X)
         MedicineReview updatedReview = existingReview.toBuilder()
                 .medicine(medicine)
-                .coMedications(request.getCoMedications())
+                .coMedications(coMedications)  // 새 coMedications 추가
                 .content(request.getContent())
                 .images(request.getImages())
                 .grade(request.getGrade())
@@ -100,11 +133,13 @@ public class MedicineReviewServiceImpl implements MedicineReviewService {
 
         MedicineReview savedReview = medicineReviewRepository.save(updatedReview);
 
-        // 약의 평균 별점을 업데이트
+        // ✅ 약의 평균 별점 업데이트
         updateMedicineRating(medicine);
 
         return savedReview; // DTO 변환 없이 엔티티를 반환
     }
+
+
 
     @Override
     @Transactional

--- a/src/main/java/com/project/foradhd/domain/medicine/persistence/entity/MedicineCoMedication.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/persistence/entity/MedicineCoMedication.java
@@ -1,0 +1,29 @@
+package com.project.foradhd.domain.medicine.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "medicine_co_medication")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MedicineCoMedication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "medicine_review_id", nullable = false)
+    private MedicineReview review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "medicine_id", nullable = false)
+    private Medicine medicine;
+}

--- a/src/main/java/com/project/foradhd/domain/medicine/persistence/entity/MedicineReview.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/persistence/entity/MedicineReview.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -45,10 +46,8 @@ public class MedicineReview extends BaseTimeEntity {
     @Column(nullable = false)
     private String profileImage;
 
-    @ElementCollection
-    @CollectionTable(name = "medicine_co_medications", joinColumns = @JoinColumn(name = "medicine_review_id"))
-    @Column(name = "medicine_id")
-    private List<Long> coMedications;
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MedicineCoMedication> coMedications = new ArrayList<>();
 
     @Column(nullable = false, columnDefinition = "longtext")
     private String content;

--- a/src/main/java/com/project/foradhd/domain/medicine/web/mapper/MedicineReviewMapper.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/web/mapper/MedicineReviewMapper.java
@@ -1,37 +1,76 @@
 package com.project.foradhd.domain.medicine.web.mapper;
 
 import com.project.foradhd.domain.medicine.persistence.entity.Medicine;
+import com.project.foradhd.domain.medicine.persistence.entity.MedicineCoMedication;
 import com.project.foradhd.domain.medicine.persistence.entity.MedicineReview;
+import com.project.foradhd.domain.medicine.persistence.repository.MedicineRepository;
 import com.project.foradhd.domain.medicine.web.dto.request.MedicineReviewRequest;
 import com.project.foradhd.domain.medicine.web.dto.response.MedicineReviewResponse;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.persistence.entity.User;
 import com.project.foradhd.domain.user.persistence.entity.UserPrivacy;
 import com.project.foradhd.domain.user.persistence.entity.UserProfile;
+import com.project.foradhd.domain.user.web.mapper.UserMapper;
+import com.project.foradhd.global.exception.BusinessException;
+import com.project.foradhd.global.exception.ErrorCode;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring")
+import java.util.List;
+
+@Mapper(componentModel = "spring", uses = {MedicineMapper.class, UserMapper.class})
 public interface MedicineReviewMapper {
 
-    @Mapping(target = "medicine.id", source = "medicineId")
+    @Mapping(target = "medicine", ignore = true) // medicine은 수동으로 설정
+    @Mapping(target = "user", ignore = true) // user도 수동 설정
+    @Mapping(target = "coMedications", ignore = true) // coMedications도 수동 설정
     @Mapping(target = "ageRange", ignore = true)
     @Mapping(target = "gender", ignore = true)
-    MedicineReview toEntity(MedicineReviewRequest request, @Context User user, @Context Medicine medicine);
+    MedicineReview toEntity(MedicineReviewRequest request);
 
-    @Mapping(target = "averageGrade", expression = "java(review.getMedicine().calculateAverageGrade())")
-    @Mapping(target = "images", source = "review.images")
-    @Mapping(target = "coMedications", source = "review.coMedications")
-    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "medicineId", source = "medicine.id") // Medicine 객체의 ID 매핑
+    @Mapping(target = "userId", source = "user.id") // User 객체의 ID 매핑
+    @Mapping(target = "coMedications", expression = "java(mapCoMedications(review.getCoMedications()))") // 리스트 매핑
     MedicineReviewResponse toResponseDto(MedicineReview review, @Context UserService userService);
+
+    // ✅ coMedications 매핑 메서드 추가 (List<MedicineCoMedication> → List<Long>)
+    default List<Long> mapCoMedications(List<MedicineCoMedication> coMedications) {
+        if (coMedications == null) return List.of();
+        return coMedications.stream()
+                .map(coMedication -> coMedication.getMedicine().getId())
+                .toList();
+    }
+
+    @AfterMapping
+    default void setUserAndMedicine(@MappingTarget MedicineReview.MedicineReviewBuilder reviewBuilder,
+                                    MedicineReviewRequest request,
+                                    @Context User user,
+                                    @Context Medicine medicine,
+                                    @Context MedicineRepository medicineRepository) {
+        // ✅ 빌더 패턴을 유지하면서 User, Medicine 설정
+        reviewBuilder
+                .user(user)
+                .medicine(medicine);
+
+        // ✅ coMedications 변환 (List<Long> → List<MedicineCoMedication>)
+        List<MedicineCoMedication> coMedications = request.getCoMedications().stream()
+                .map(medicineId -> {
+                    Medicine coMedicine = medicineRepository.findById(medicineId)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
+                    return MedicineCoMedication.builder().medicine(coMedicine).build();
+                })
+                .toList();
+
+        reviewBuilder.coMedications(coMedications);
+    }
 
     @AfterMapping
     default void setUserProfileDetails(@MappingTarget MedicineReviewResponse.MedicineReviewResponseBuilder responseBuilder,
                                        MedicineReview review,
                                        @Context UserService userService) {
-        // 리뷰의 유저 ID를 사용해 실시간으로 유저 정보를 가져옴
+        // ✅ 유저 ID를 사용해 프로필 정보 가져오기
         UserProfile userProfile = userService.getUserProfile(review.getUser().getId());
         UserPrivacy userPrivacy = userService.getUserPrivacy(review.getUser().getId());
 
@@ -46,7 +85,25 @@ public interface MedicineReviewMapper {
     }
 
     @AfterMapping
+    default void setMedicineAndCoMedications(@MappingTarget MedicineReview.MedicineReviewBuilder reviewBuilder,
+                                             MedicineReviewRequest request,
+                                             @Context MedicineRepository medicineRepository) {
+        // ✅ coMedications 변환
+        List<MedicineCoMedication> coMedications = request.getCoMedications().stream()
+                .map(medicineId -> {
+                    Medicine coMedicine = medicineRepository.findById(medicineId)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEDICINE));
+                    return MedicineCoMedication.builder()
+                            .medicine(coMedicine)
+                            .build();
+                })
+                .toList();
+        reviewBuilder.coMedications(coMedications);
+    }
+
+    @AfterMapping
     default void setMedicineId(@MappingTarget MedicineReviewResponse.MedicineReviewResponseBuilder responseBuilder, MedicineReview review) {
         responseBuilder.medicineId(review.getMedicine().getId());
     }
 }
+

--- a/src/main/java/com/project/foradhd/global/validation/validator/EmailDomainValidator.java
+++ b/src/main/java/com/project/foradhd/global/validation/validator/EmailDomainValidator.java
@@ -1,0 +1,28 @@
+package com.project.foradhd.global.validation.validator;
+
+import javax.naming.directory.*;
+import javax.naming.Context;
+import java.util.Hashtable;
+
+public class EmailDomainValidator {
+
+    /**
+     * 주어진 도메인이 이메일을 수신할 수 있는지 MX 레코드 조회를 통해 검증
+     */
+    public static boolean isDomainValid(String domain) {
+        try {
+            // DNS 조회를 위한 환경 설정
+            Hashtable<String, String> env = new Hashtable<>();
+            env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+
+            // DNS MX 레코드 조회
+            DirContext ctx = new InitialDirContext(env);
+            Attributes attrs = ctx.getAttributes(domain, new String[]{"MX"});
+            Attribute attr = attrs.get("MX");
+
+            return attr != null && attr.size() > 0; // MX 레코드가 존재하면 유효한 도메인
+        } catch (Exception e) {
+            return false; // 도메인이 존재하지 않거나 MX 레코드 조회 실패
+        }
+    }
+}

--- a/src/main/java/com/project/foradhd/global/validation/validator/EmailValidator.java
+++ b/src/main/java/com/project/foradhd/global/validation/validator/EmailValidator.java
@@ -20,6 +20,7 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
             "hotmail.com", "outlook.com", "facebook.com");
     private static final String EMAIL_AT_SYMBOL = "@";
     private static final String EMAIL_DOMAIN_VALIDATION_MESSAGE_CODE = "email.notSupported.domain";
+    private static final String EMAIL_FORMAT_VALIDATION_MESSAGE_CODE = "email.invalid.format";
 
     private final MessageSource validationMessageSource;
 
@@ -32,7 +33,7 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
         }
     }
 
-    @Override
+/*    @Override
     public boolean isValid(String email, ConstraintValidatorContext context) {
         if (!StringUtils.hasText(email) ||
                 !email.matches(emailRegex)) {
@@ -46,10 +47,25 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
             return false;
         }
         return true;
+    }*/
+
+    @Override
+    public boolean isValid(String email, ConstraintValidatorContext context) {
+        if (!StringUtils.hasText(email) || !email.matches(emailRegex)) {
+            setValidationMessage(context, EMAIL_FORMAT_VALIDATION_MESSAGE_CODE);
+            return false; // 이메일 형식이 올바르지 않음
+        }
+
+        return true; // 형식만 맞으면 허용
     }
 
     private String parseDomain(String email) {
-        if (!email.matches(DEFAULT_EMAIL_REGEX)) return "";
-        return email.split(EMAIL_AT_SYMBOL)[1];
+        return email.substring(email.indexOf(EMAIL_AT_SYMBOL) + 1);
+    }
+
+    private void setValidationMessage(ConstraintValidatorContext context, String messageCode) {
+        String message = validationMessageSource.getMessage(messageCode, null, Locale.KOREA);
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
     }
 }


### PR DESCRIPTION
## 💻 구현 내용 
**🚀 MedicineCoMedication 엔티티 추가 및 기존 로직 개선**
- MedicineReview와 Medicine 간 다대다(@ManyToMany) 관계를 다루기 위해 중간 테이블을 별도의 엔티티(`MedicineCoMedication`)로 분리
- 기존에는 medicine_co_medications 테이블을 Hibernate에서 자동 생성했지만, 명시적인 엔티티로 관리하도록 변경
- 새로운 엔티티의 테이블명을 `medicine_co_medication`(s빠짐!!) 으로 지정하여 기존 테이블과 충돌을 방지
- 
**🔄 MedicineReview와 MedicineCoMedication 관계 설정**
- 기존에는 MedicineReview가 medicine_id를 리스트로 직접 관리했지만 **중간 엔티티**(`MedicineCoMedication`)를 통해 연관관계를 관리
- `MedicineReview` **저장 이후** `MedicineCoMedication` **엔티티를 생성**하여 연관 데이터를 추가

## 🛠️ 개발 오류 사항
❌ **오류:** `Field 'review_id' doesn't have a default value`
- 원인: 
    `review_id`가 NULL인 상태에서 `medicine_co_medications`에 데이터가 삽입됨
- 해결 방법:
    `MedicineReview` 엔티티를 먼저 저장한 후 `MedicineCoMedication`을 추가하도록 코드 수정
     Lambda 표현식에서 `medicineReview`가 effectively final 상태로 유지되도록 변경

❌ **오류**: `Incorrect table definition; there can be only one auto column and it must be defined as a key`
원인: 
    Hibernate가 기존 `medicine_co_medications` 테이블을 자동 생성하려 했으나, 새로운 엔티티와 충돌
해결 방법: 
    새로운 엔티티의 테이블명을 `medicine_co_medication`으로 변경 (s 빠짐!!)

## 🗣️ For 리뷰어
- 새로운 `MedicineCoMedication` 엔티티가 추가되면서 **데이터 마이그레이션 필요 여부** 검토
- 기존 `medicine_co_medications` 테이블을 사용하는 코드가 있는지 확인 필요 (제가 확인했을 때는 없었습니다)
- `MedicineReview`와 `MedicineCoMedication` 간의 관계 설정이 올바르게 되어 있는지 검토 부탁드립니다 

close #121 