### PR TITLE
게시글 & 카테고리별 랭킹순 조회 isBlocked 필드 미반환 및 전체 게시글 조회 api isBlocked 필드 null 반환 

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
@@ -215,11 +215,15 @@ public class PostController {
 
     // 메인홈 - 실시간 랭킹
     @GetMapping("/main/top")
-    public ResponseEntity<PostRankingResponseDto.PagedPostRankingResponseDto> getTopPosts(Pageable pageable) {
+    public ResponseEntity<PostRankingResponseDto.PagedPostRankingResponseDto> getTopPosts(@AuthUserId String userId, Pageable pageable) {
         Page<Post> postPage = postService.getTopPosts(pageable);
 
+        List<String> blockedUserIdList = userService.getBlockedUserIdList(userId);
+
         List<PostRankingResponseDto> postList = postPage.getContent().stream()
-                .map(postMapper::toPostRankingResponseDto)
+                .map(post -> postMapper.toPostRankingResponseDto(
+                        post, blockedUserIdList
+                ))
                 .toList();
 
         PagingResponse pagingResponse = PagingResponse.from(postPage);
@@ -236,12 +240,17 @@ public class PostController {
     // 메인홈 - 카테고리별 실시간 랭킹
     @GetMapping("/main/top/category")
     public ResponseEntity<PostRankingResponseDto.PagedPostRankingResponseDto> getTopPostsByCategory(
+            @AuthUserId String userId,
             @RequestParam("category") Category category,
             Pageable pageable) {
         Page<Post> postPage = postService.getTopPostsByCategory(category, pageable);
 
+        List<String> blockedUserIdList = userService.getBlockedUserIdList(userId);
+
         List<PostRankingResponseDto> postList = postPage.getContent().stream()
-                .map(postMapper::toPostRankingResponseDto)
+                .map(post -> postMapper.toPostRankingResponseDto(
+                        post, blockedUserIdList
+                ))
                 .toList();
 
         PagingResponse pagingResponse = PagingResponse.from(postPage);

--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostRankingResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/PostRankingResponseDto.java
@@ -27,6 +27,9 @@ public class PostRankingResponseDto {
     @JsonSerialize(using = LocalDateTimeToEpochSecondSerializer.class)
     private LocalDateTime createdAt;
     private List<String> images;
+    private Boolean isBlocked;
+
+
 
     @Getter
     @Builder

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
@@ -76,7 +76,7 @@ public interface PostMapper {
     @Mapping(source = "isAuthor", target = "isAuthor")
     @Mapping(target = "nickname", expression = "java(getNickname(post, userService))")
     @Mapping(target = "profileImage", expression = "java(getProfileImage(post, userService))")
-    @Mapping(target = "isBlocked", ignore = true)
+    @Mapping(target = "isBlocked", expression = "java(isBlockedUser(post, blockedUserIdList))")
     PostListResponseDto.PostResponseDto toPostResponseDto(
             Post post,
             UserService userService,
@@ -123,6 +123,11 @@ public interface PostMapper {
 
         boolean isBlocked = post.getUser() != null && blockedUserIdList.contains(post.getUser().getId());
         dtoBuilder.isBlocked(isBlocked);
+    }
+
+    // ✅ 차단된 사용자 여부 확인 함수
+    default boolean isBlockedUser(Post post, List<String> blockedUserIdList) {
+        return post.getUser() != null && blockedUserIdList.contains(post.getUser().getId());
     }
 
     // ✅ 빌더 패턴 적용: 댓글 리스트 매핑 추가 (부모 댓글만 반환)

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/PostMapper.java
@@ -159,9 +159,10 @@ public interface PostMapper {
                 .sum();
     }
 
-    @Mapping(source = "category", target = "category")
-    @Mapping(source = "user.id", target = "userId")
-    PostRankingResponseDto toPostRankingResponseDto(Post post);
+    @Mapping(source = "post.category", target = "category")
+    @Mapping(source = "post.user.id", target = "userId")
+    @Mapping(target = "isBlocked", expression = "java(isBlockedUser(post, blockedUserIdList))")
+    PostRankingResponseDto toPostRankingResponseDto(Post post, List<String> blockedUserIdList);
 
     @Mapping(source = "title", target = "title")
     @Mapping(source = "viewCount", target = "viewCount")


### PR DESCRIPTION
## 💻 구현 내용 

- 전체 게시글 isBlocked null 반환 에러 해결
- 게시글 & 카테고리별 랭킹순 조회 isBlocked 필드 반환 하도록 수정

## 🛠️ 개발 오류 사항
- 해당 사항 없음


## 🗣️ For 리뷰어

- 오타와 같은 부분이 있는지 확인 부탁 드립니다.

close #123 