### PR TITLE
fix: 게시글 댓글 조회시 500에러 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentLikeFilterRepository.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentLikeFilterRepository.java
@@ -4,6 +4,7 @@ import com.project.foradhd.domain.board.persistence.entity.CommentLikeFilter;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -22,4 +23,8 @@ public interface CommentLikeFilterRepository extends JpaRepository<CommentLikeFi
     @Query("UPDATE Comment c SET c.likeCount = c.likeCount - 1 WHERE c.id = :commentId")
     void decrementLikeCount(Long commentId);
     boolean existsByUserIdAndCommentId(String userId, Long commentId);
+    @Query("SELECT CASE WHEN COUNT(clf) > 0 THEN true ELSE false END " +
+            "FROM CommentLikeFilter clf WHERE clf.user.id = :userId AND clf.comment.id = :commentId")
+    boolean isUserLikedComment(@Param("userId") String userId, @Param("commentId") Long commentId);
+
 }


### PR DESCRIPTION
**## 💻 구현 내용** 
**🔹 댓글 매핑 방식 변경 (`@AfterMapping` 적용)**
**✅ 기존 방식**
- 기존에는 `mapCommentList`를 `@Mapping `단계에서 직접 호출하여 댓글 리스트를 매핑함

**🔧 해결 방법**
- `@Mapping`에서 `comments` 필드를 `ignore = true`로 변경
- `@AfterMapping`을 활용하여, 매핑이 완료된 후 댓글 리스트를 추가하는 방식으로 변경
- CommentMapper, UserService, CommentService, blockedUserIdList, loggedInUserId 등을 @Context로 전달하여,
의존성을 주입받아 `mapCommentList`를 실행하도록 변경

**## 🛠️ 개발 오류 사항**
**❌ 오류: CommentMapper.INSTANCE 접근 문제 및 매핑 오류**
**✅ 원인**
- 기존 방식에서는 `@Mapping `단계에서 `mapCommentList`를 호출했기 때문에, MapStruct가 의존성을 자동으로 주입하지 못함
- `CommentMapper.INSTANCE`를 직접 참조하는 방식이었으므로, MapStruct에서 이를 해석하지 못하고 오류 발생
- 또한 `isUserLikedComment`, `isCommentAuthor` 등의 사용자 기반 정보는 @Mapping 단계에서 접근 불가능
**🔧 해결 방법**
@Mapping에서 comments 필드를 ignore = true로 변경
@AfterMapping에서 mapCommentList를 호출하여 댓글 리스트를 설정

## 🗣️ For 리뷰어
✅ `@Mapping`에서 `comments`를 `ignore = true`로 설정한 것이 적절한지
✅ `@AfterMapping`에서 `commentMapper.commentToCommentResponseDto`를 호출하는 방식이 올바른지
✅ 혹시 더 최적화할 부분이 있다면 피드백 부탁드립니다.

close #134 