### PR TITLE
fix: 대댓글 작성 시 댓글 중복 업로드 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
@@ -158,7 +158,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public Page<Comment> getCommentsByPost(Long postId, Pageable pageable, SortOption sortOption) {
         pageable = applySorting(pageable, sortOption);
-        return commentRepository.findByPostId(postId, pageable);
+        return commentRepository.findTopLevelCommentsWithChildren(postId, pageable);
     }
 
     @Override

--- a/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentRepository.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/repository/CommentRepository.java
@@ -51,4 +51,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("DELETE FROM Comment c WHERE c.id = :id")
     void deleteCommentById(Long id);
     boolean existsByIdAndUserId(Long id, String userId);
+    Page<Comment> findByPostIdAndParentCommentIsNull(Long postId, Pageable pageable);
+    @EntityGraph(attributePaths = {
+            "user",
+            "user.userProfile",
+            "childComments",
+            "childComments.user",
+            "childComments.user.userProfile"
+    })
+    @Query("SELECT c FROM Comment c WHERE c.post.id = :postId AND c.parentComment IS NULL")
+    Page<Comment> findTopLevelCommentsWithChildren(@Param("postId") Long postId, Pageable pageable);
 }


### PR DESCRIPTION
## 💻 구현 내용 
- 댓글 목록 조회 시 대댓글이 최상단 댓글 리스트에 중복 노출되는 현상 제거
- 기존에는 `postId`로 조회할 때 대댓글도 함께 불러와 `children`에도, 최상단에도 중복으로 표시됨
- `parentComment is null `조건을 걸어 **최상위 댓글만 조회하도록 변경**
- 댓글 + 대댓글 + 유저 + 유저 프로필을 `@EntityGraph`로 `Fetch Join` 처리
- 댓글 수가 많지 않아도 `N+1 쿼리 문제`로 인해 느리던 성능 이슈 해결
- 🔥 조회 시간이 **14초 → 4초** 이내로 단축 🔥

## 🛠️ 개발 오류 사항
- 기존 댓글 조회 API에서 대댓글이 `parentComment != null`인데도 리스트 최상단에 노출되는 이슈가 발생함
- `comment.getChildComments()`에서 `children`으로도 포함되고 `findByPostId()`로 전체 댓글을 가져오며 대댓글도 함께 포함됨 → 중복 표시됨
- 또한 댓글 수는 적은데 **N+1 문제로 인한 응답 지연**이 발생
    - userProfile, isLiked, isCommentAuthor 등을 댓글마다 개별 쿼리로 조회하고 있었음
**🥟 해결 방법**
- `findByPostIdAndParentCommentIsNull(postId)`로 최상위 댓글만 조회하도록 변경
- `@EntityGraph`를 활용해 댓글 + 대댓글 + 유저 + 유저 프로필까지 `Fetch Join `처리

## 🗣️ For 리뷰어
- 기존 댓글 조회 API 응답 구조는 그대로 유지하면서 중복 제거 및 성능 개선에 집중했습니다.
- 성능 테스트 결과 동일 데이터 기준에서 14초 걸리던 응답 시간이 4초 이하로 감소함을 확인했습니다.
- `CommentMapper` 내 `childComments` 매핑 시에도 성능을 고려해 불필요한 쿼리 최소화 전략 적용되어 있습니다.

close #149 