### PR TITLE
feat: 비밀번호 변경 시 기존 비밀번호랑 동일할 경우 에러 처리

### DIFF
--- a/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/user/business/service/impl/UserServiceImpl.java
@@ -6,7 +6,6 @@ import com.project.foradhd.domain.user.business.service.UserAuthInfoService;
 import com.project.foradhd.domain.user.business.service.UserService;
 import com.project.foradhd.domain.user.persistence.entity.*;
 import com.project.foradhd.domain.user.persistence.enums.Provider;
-import com.project.foradhd.domain.user.persistence.enums.Role;
 import com.project.foradhd.domain.user.persistence.repository.*;
 import com.project.foradhd.global.exception.BusinessException;
 import java.time.LocalDate;
@@ -144,6 +143,10 @@ public class UserServiceImpl implements UserService {
     public void updatePassword(String userId, PasswordUpdateData passwordUpdateData) {
         String prevPassword = passwordUpdateData.getPrevPassword();
         String newPassword = passwordUpdateData.getPassword();
+
+        if (prevPassword.equals(newPassword)) {
+            throw new BusinessException(PASSWORD_SAME_AS_PREVIOUS);
+        }
         userAuthInfoService.validatePasswordMatches(userId, prevPassword);
         userAuthInfoService.updatePassword(userId, newPassword);
     }

--- a/src/main/java/com/project/foradhd/global/exception/ErrorCode.java
+++ b/src/main/java/com/project/foradhd/global/exception/ErrorCode.java
@@ -69,7 +69,8 @@ public enum ErrorCode {
     ALREADY_LIKED_COMMENT(CONFLICT, "이미 좋아요한 댓글입니다."),
 
     // notification
-    NOT_FOUND_NOTIFICATION(NOT_FOUND, "존재하지 않는 알림입니다.");
+    NOT_FOUND_NOTIFICATION(NOT_FOUND, "존재하지 않는 알림입니다."),
+    PASSWORD_SAME_AS_PREVIOUS(BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 }


### PR DESCRIPTION
## 💻 구현 내용 
**비밀번호 변경 시 기존 비밀번호와 동일한 경우 예외 처리 추가**
- 사용자가 기존 비밀번호와 동일한 비밀번호로 변경을 시도할 경우, `BusinessException`을 발생시켜 변경을 막도록 로직을 추가했습니다.
- 사용자 실수로 인해 동일한 비밀번호를 재사용하는 것을 방지하고, 보안성 향상을 위해 필요한 제약 조건입니다.

**상세 로직**
- `UserServiceImpl`의 `updatePassword` 메서드 내에서 기존 비밀번호와 새 비밀번호를 비교
- 동일할 경우 `PASSWORD_SAME_AS_PREVIOUS` 에러 코드와 함께 예외 발생

## 🛠️ 개발 오류 사항


## 🗣️ For 리뷰어
- 비밀번호 변경 시 기존 비밀번호와 동일한지 확인하는 로직이 `UserServiceImpl` 내부에서 수행되도록 수정했습니다.
- 보안 정책 및 사용자 경험 관점에서 이 예외 처리 로직이 적절한지 + 위치나 방식이 개선될 여지가 있는지 함께 확인 부탁드립니다.
- 기존 비밀번호와 같은 비밀번호를 입력했을 경우 or 기존 사용 중인 비밀번호를 잘못 입력했을 경우 에러 처리가 제대로 수행되는지 확인 부탁드립니다.

close #149 