### PR TITLE
fix: 카테고리 별 글 조회 시 정렬옵션 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
@@ -112,18 +112,18 @@ public class PostServiceImpl implements PostService {
 
     // 글 카테고리별 정렬
     @Override
-    public Page<Post> listByCategory(Category category, Pageable pageable) {
+    public Page<Post> listByCategory(Category category, Pageable pageable, SortOption sortOption) {
         if (category == null) {
             throw new BusinessException(INVALID_REQUEST);
         }
-        Page<Post> posts = postRepository.findByCategory(category, pageable);
+        Pageable sortedPageable = applySorting(pageable, sortOption);
+        Page<Post> posts = postRepository.findByCategory(category, sortedPageable);
 
         if (posts.isEmpty()) {
             throw new BusinessException(NOT_FOUND_POST);
         }
         return posts;
     }
-
     // 글 조회수 증가
     @Override
     @Transactional
@@ -202,4 +202,5 @@ public class PostServiceImpl implements PostService {
         postSearchHistoryService.saveSearchTerm(userId, title);
         return postRepository.findByTitleContaining(title, pageable);
     }
+
 }

--- a/src/main/java/com/project/foradhd/domain/board/business/service/PostService.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/PostService.java
@@ -19,7 +19,7 @@ public interface PostService {
     Post updatePost(Post post);
 
     // 특정 카테고리의 게시글 목록 조회
-    Page<Post> listByCategory(Category category, Pageable pageable);
+    Page<Post> listByCategory(Category category, Pageable pageable, SortOption sortOption);
 
     // 게시글 삭제
     void deletePost(Long Id);

--- a/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/PostController.java
@@ -135,9 +135,13 @@ public class PostController {
     // 카테고리별 게시글 조회 API
     @GetMapping("/category")
     public ResponseEntity<PostListResponseDto> getPostsByCategory(
-            @RequestParam("category") Category category, Pageable pageable, @AuthUserId String userId, CommentService commentService) {
+            @RequestParam("category") Category category,
+            Pageable pageable,
+            @RequestParam(defaultValue = "NEWEST_FIRST") SortOption sortOption,
+            @AuthUserId String userId,
+            CommentService commentService) {
 
-        Page<Post> postPage = postService.listByCategory(category, pageable);
+        Page<Post> postPage = postService.listByCategory(category, pageable, sortOption);
         List<String> blockedUserIdList = userService.getBlockedUserIdList(userId);
 
         List<PostListResponseDto.PostResponseDto> postResponseDtoList = postPage.getContent().stream()
@@ -149,12 +153,13 @@ public class PostController {
                         postLikeFilterService.isUserLikedPost(userId, post.getId()),
                         post.getUser().getId().equals(userId),
                         userId,
-                        commentService ))
+                        commentService))
                 .filter(postResponseDto -> postResponseDto.getIsBlocked() == null || !postResponseDto.getIsBlocked())
                 .toList();
 
         return ResponseEntity.ok(new PostListResponseDto(postResponseDtoList, PagingResponse.from(postPage)));
     }
+
 
     // 내가 작성한 게시글 조회 api
     @GetMapping("/my-posts")


### PR DESCRIPTION
## 💻 구현 내용 
**카테고리별 게시글 최신순 정렬 기능 개선**
- 기존에는 `/api/v1/posts/category` 요청 시 `SortOption` 파라미터가 무시되어 항상 기본 정렬(`createdAt DESC`)로 작동했습니다.
- 이를 해결하기 위해 `PostController`, `PostService`, `PostServiceImpl`에 정렬 옵션(`SortOption`)을 반영한 로직을 추가하였습니다.
- 정렬 기준에는 최신순(`NEWEST_FIRST`), 오래된순(OLDEST_FIRST), 조회수순(`MOST_VIEWED`), 좋아요순(`MOST_LIKED`), 댓글순(`MOST_COMMENTED`) 등을 지원합니다.

## 🛠️ 개발 오류 사항
- 문제: 
프론트에서 `sortOption=NEWEST_FIRST`로 요청을 보내도 정렬이 적용되지 않음.
- 원인 분석: 
`PostServiceImpl`의 `listByCategory` 메서드에 `SortOption` 파라미터가 없었고, 내부에서도 정렬 처리가 누락되어 있었음.
- 해결 방법:
`listByCategory` 메서드에 `SortOption`을 추가하고, 이를 기반으로 `Pageable`에 정렬 기준을 적용하는 `applySorting` 메서드를 작성하여 동적으로 정렬 가능하도록 개선함

## 🗣️ For 리뷰어
- `/api/v1/posts/category` API에서 `sortOption` 쿼리 파라미터를 기반으로 동작이 잘 적용되었는지 확인 부탁드립니다.
- 서비스 계층에서 동작하는 정렬 기준이 실제로 Query에 잘 반영되었는지, 그리고 `SortOption`이 적절히 적용되는지 봐주시면 좋습니다.
close #152 