### PR TITLE
회원탈퇴 500에러 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserProfile.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserProfile.java
@@ -43,7 +43,7 @@ public class UserProfile extends BaseTimeEntity {
     }
 
     public void withdraw() {
-        this.nickname = "";
+        this.nickname = "withdrawn_" + this.id;
         this.profileImage = "";
     }
 }

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserProfile.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/UserProfile.java
@@ -3,6 +3,7 @@ package com.project.foradhd.domain.user.persistence.entity;
 import com.project.foradhd.domain.user.persistence.enums.ForAdhdType;
 import com.project.foradhd.global.audit.BaseTimeEntity;
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,7 +44,7 @@ public class UserProfile extends BaseTimeEntity {
     }
 
     public void withdraw() {
-        this.nickname = "withdrawn_" + this.id;
+        this.nickname = "withdrawn_" + UUID.randomUUID();
         this.profileImage = "";
     }
 }


### PR DESCRIPTION
## 💻 구현 내용 

- 회원 탈퇴 요청시 500에러 수정

## 🛠️ 개발 오류 사항

- 회원 탈퇴시 UserProfile에 nickname이 공백 상태로 저장 되도록 하는 로직이었습니다
- nickname에는 중복 제약이 걸려있어 여러 유저가 탈퇴를 할 경우 중복 에러 때문에 탈퇴가 되지 않음을 확인 했습니다.
- nickname에 탈퇴한 유저가 명시 되도록 수정해주었습니다.

## 🗣️ For 리뷰어

- 더 좋은 방법이 있다면 말씀해주세요

close #154 