### PR TITLE
mod: 댓글 soft delete 되도록 수정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/persistence/entity/Comment.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/entity/Comment.java
@@ -57,4 +57,10 @@ public class Comment extends BaseTimeEntity {
     private String nickname;
 
     private String profileImage;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    @Column
+    private String deletedMessage;
 }

--- a/src/main/java/com/project/foradhd/domain/board/web/dto/response/CommentListResponseDto.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/dto/response/CommentListResponseDto.java
@@ -37,5 +37,6 @@ public class CommentListResponseDto {
         private Boolean isBlocked;
         private final Boolean isLiked;
         private final Boolean isCommentAuthor;
+        private boolean isDeleted;
     }
 }

--- a/src/main/java/com/project/foradhd/domain/board/web/mapper/CommentMapper.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/mapper/CommentMapper.java
@@ -70,8 +70,11 @@ public interface CommentMapper {
     }
 
 
-    // ✅ 닉네임 가져오는 함수
+    // ✅ 닉네임 가져오는 함수 (삭제된 댓글 대응)
     default String getNickname(Comment comment, UserService userService) {
+        if (Boolean.TRUE.equals(comment.isDeleted())) {
+            return "(삭제)";
+        }
         if (comment.getAnonymous()) {
             return "익명";
         }
@@ -84,8 +87,11 @@ public interface CommentMapper {
         return "알 수 없음";
     }
 
-    // ✅ 프로필 이미지 가져오는 함수
+    // ✅ 프로필 이미지 가져오는 함수 (삭제된 댓글 대응)
     default String getProfileImage(Comment comment, UserService userService) {
+        if (Boolean.TRUE.equals(comment.isDeleted())) {
+            return "image/default-profile.png";
+        }
         if (comment.getAnonymous()) {
             return "image/default-profile.png";
         }


### PR DESCRIPTION
## 💻 구현 내용 
**1. Soft Delete 기반 댓글 삭제 처리 로직 개선**
- 기존에는 댓글 삭제 시 DB에서 완전 삭제되어 댓글 목록 조회 시 아예 보이지 않음
- 이를 개선하여 대댓글이 존재하는 원댓글의 경우 실제 삭제하지 않고 `"삭제된 댓글입니다." `형태로 남기도록 변경
- 댓글 엔티티에 `deleted`, `deletedMessage` 필드 추가

- 매퍼에서 `isDeleted` 상태일 경우:
- `nickname` → (삭제)
- `content` → "삭제된 댓글입니다."
- `profileImage` → 기본 이미지로 대체

- 삭제된 댓글도 조회 리스트에 포함되도록 `CommentRepository`의 `JPQL` 수정

## 🛠️ 개발 오류 사항
- 댓글 `soft delete` 처리 후 삭제된 댓글이 댓글 목록 API에서 아예 보이지 않는 현상 발생
- 원인: `findTopLevelCommentsWithChildren` JPQL 쿼리에 `isDeleted = false` 조건이 포함되어 있었음
- 해결: 해당 조건 제거하여 `soft deleted` 댓글도 포함되도록 수정

## 🗣️ For 리뷰어
- 삭제된 댓글이 어떻게 응답에 포함되는지 확인해주세요. (글 별 댓글 조회 `api {{host}}/api/v1/comments/posts/{{postId}}?sortOption=NEWEST_FIRST&page=0&size=10` 와, 개별 댓글 조회 api `{{host}}/api/v1/comments/{{commentId}}`)
- 삭제된 댓글은 `nickname`: (삭제), `content`: 삭제된 댓글입니다. 로 표현됩니다.
- 대댓글이 있는 댓글을 삭제해도 대댓글은 그대로 유지되며 삭제된 부모 댓글만 soft delete 처리됩니다.
- 혹시 기존 댓글 관련 로직에 영향이 없는지 한 번 더 체크 부탁드립니다!

close #156 