### PR TITLE
fix: 댓글 작성 시 deleted 필드 기본값 설정

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/persistence/entity/Comment.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/entity/Comment.java
@@ -58,7 +58,9 @@ public class Comment extends BaseTimeEntity {
 
     private String profileImage;
 
+    @Builder.Default
     @Column(nullable = false)
+    @ColumnDefault("false")
     private boolean deleted = false;
 
     @Column

--- a/src/main/java/com/project/foradhd/domain/board/persistence/entity/Post.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/entity/Post.java
@@ -31,7 +31,7 @@ public class Post extends BaseTimeEntity {
     @Column(name = "category")
     private Category category;
 
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Comment> comments;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 💻 구현 내용 
**🔧 default 값 문제 해결**
- 초기 댓글 생성 시 `deleted` 필드에 `default` 값이 없어 다음과 같은 에러가 발생했습니다.
- `Field 'deleted' doesn't have a default value`

- 이를 해결하기 위해 `@Column(nullable = false)`에` @ColumnDefault("false")` 어노테이션을 추가하고,
- `@Builder.Default private boolean deleted = false;`로 명시적인 초기값을 설정했습니다.

## 🛠️ 개발 오류 사항

## 🗣️ For 리뷰어
- soft delete 로직을 위해 `boolean` 필드(`deleted`)에 대한 default 값 처리에 주의했습니다.
- 혹시 해당 방식 외에 더 안정적이거나 추천하는 방식이 있다면 공유 부탁드립니다!

close #158 