### PR TITLE
mod: 카테고리 별 글 조회 시 글 없을 경우 빈 리스트 반환

### DIFF
--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
@@ -118,10 +118,6 @@ public class PostServiceImpl implements PostService {
         }
         Pageable sortedPageable = applySorting(pageable, sortOption);
         Page<Post> posts = postRepository.findByCategory(category, sortedPageable);
-
-        if (posts.isEmpty()) {
-            throw new BusinessException(NOT_FOUND_POST);
-        }
         return posts;
     }
     // 글 조회수 증가


### PR DESCRIPTION
## 💻 구현 내용 
- `카테고리별 글 정렬 API(listByCategory)`에서 해당 카테고리에 등록된 글이 없는 경우에도 `BusinessException(NOT_FOUND_POST)`을 발생시키지 않고, 빈 리스트를 반환하도록 수정하였습니다.
- 기존에는 글이 하나도 없는 경우 예외가 발생했음
- 변경 후에는` Page<Post>` 객체를 그대로 반환하므로, 프론트에서` .isEmpty()` 여부로 처리할 수 있습니다.

## 🛠️ 개발 오류 사항
- 문제: 카테고리에 글이 존재하지 않으면 `BusinessException(NOT_FOUND_POST)` 예외가 발생하여 404 오류로 응답되던 문제.
- 해결: if (posts.isEmpty()) 조건을 제거하여 빈 리스트를 200 OK와 함께 반환하도록 변경.

## 🗣️ For 리뷰어
- PostServiceImpl의 listByCategory 메서드 내 조건문 제거로 처리했습니다.

close #160 