### PR TITLE
fix: 비밀번호 특수문자 수정

### DIFF
--- a/src/main/java/com/project/foradhd/global/validation/validator/PasswordValidator.java
+++ b/src/main/java/com/project/foradhd/global/validation/validator/PasswordValidator.java
@@ -16,7 +16,7 @@ import java.util.Locale;
 public class PasswordValidator implements ConstraintValidator<ValidPassword, PasswordRequest> {
 
     //숫자, 영문, 특수문자 조합 8자리 이상(공백 문자 포함X)
-    private static final String DEFAULT_PASSWORD_REGEX = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,}$";
+    private static final String DEFAULT_PASSWORD_REGEX = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[^a-zA-Z0-9])(?=\\S+$).{8,}$";
     private static final String PASSWORD_REGEX_VALIDATION_MESSAGE_CODE = "password.invalid.format";
     private static final String PASSWORD_CONFIRM_VALIDATION_MESSAGE_CODE = "password.notMatches.passwordConfirm";
     private final MessageSource validationMessageSource;


### PR DESCRIPTION
## 💻 구현 내용 
**비밀번호 정규식 수정**
- 기존 정규식은 제한된 일부 특수문자만 허용 (`[@#$%^&+=!.]`)
- 모든 특수문자 허용을 위해 정규식 수정
`// 변경 전
private static final String DEFAULT_PASSWORD_REGEX = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,}$";

// 변경 후
private static final String DEFAULT_PASSWORD_REGEX = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[^a-zA-Z0-9])(?=\\S+$).{8,}$";
`

- 설명:
    - 숫자(0-9) 1개 이상
    - 영문자(a-zA-Z) 1개 이상
    - 특수문자([^a-zA-Z0-9]) 1개 이상
    - 공백 없이 총 8자 이상

## 🛠️ 개발 오류 사항
- 문제점: 기존 정규식에서는 .(dot) 등 일부 특수문자가 허용되지 않아 사용자가 예상한 입력값이 실패하는 문제가 있었음
- 해결 방법: 특수문자 범위를 [`^a-zA-Z0-9`]로 확장하여 대부분의 특수문자 허용

## 🗣️ For 리뷰어
- 변경된 정규식이 보안 요건(숫자 + 영문 + 특수문자 + 공백 제외 + 8자 이상)을 모두 충족하는지 확인 부탁드립니다
- 혹시 더 강력한 정책(예: 대소문자 구분 포함 등)이 필요하다면 코멘트 주세요


close #168 