### PR TITLE
mod: 약 리뷰 조회 시 작성자 확인 필드 추가

### DIFF
--- a/src/main/java/com/project/foradhd/domain/medicine/business/service/impl/MedicineReviewServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/business/service/impl/MedicineReviewServiceImpl.java
@@ -150,6 +150,8 @@ public class MedicineReviewServiceImpl implements MedicineReviewService {
             throw new BusinessException(ErrorCode.FORBIDDEN_MEDICINE_REVIEW);
         }
 
+        medicineReviewLikeRepository.deleteByMedicineReviewId(reviewId);
+        medicineReview.getCoMedications().clear();
         // 리뷰 삭제
         medicineReviewRepository.deleteById(reviewId);
 

--- a/src/main/java/com/project/foradhd/domain/medicine/persistence/repository/MedicineReviewLikeRepository.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/persistence/repository/MedicineReviewLikeRepository.java
@@ -7,4 +7,5 @@ public interface MedicineReviewLikeRepository extends JpaRepository<MedicineRevi
 
     boolean existsByUserIdAndMedicineReviewId(String userId, Long reviewId);
     void deleteByUserIdAndMedicineReviewId(String userId, Long reviewId);
+    void deleteByMedicineReviewId(Long reviewId);
 }

--- a/src/main/java/com/project/foradhd/domain/medicine/persistence/repository/MedicineReviewRepository.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/persistence/repository/MedicineReviewRepository.java
@@ -14,32 +14,32 @@ import java.util.Optional;
 @Repository
 public interface MedicineReviewRepository extends JpaRepository<MedicineReview, Long> {
 
-    // 리뷰 ID로 유저 프로필 및 개인정보와 함께 조회
-    @Query("""
-        SELECT r FROM MedicineReview r
-        JOIN FETCH r.user u
-        JOIN UserProfile up ON up.user.id = u.id
-        JOIN UserPrivacy uv ON uv.user.id = u.id
-        WHERE r.id = :reviewId
-        """)
-    Optional<MedicineReview> findByIdWithUserDetails(@Param("reviewId") Long reviewId);
+//    // 리뷰 ID로 유저 프로필 및 개인정보와 함께 조회
+//    @Query("""
+//        SELECT r FROM MedicineReview r
+//        JOIN FETCH r.user u
+//        JOIN UserProfile up ON up.user.id = u.id
+//        JOIN UserPrivacy uv ON uv.user.id = u.id
+//        WHERE r.id = :reviewId
+//        """)
+//    Optional<MedicineReview> findByIdWithUserDetails(@Param("reviewId") Long reviewId);
 
-    // 특정 유저의 모든 리뷰를 유저 프로필 및 개인정보와 함께 조회
-    @Query("""
-        SELECT r FROM MedicineReview r
-        JOIN FETCH r.user u
-        JOIN UserProfile up ON up.user.id = u.id
-        JOIN UserPrivacy uv ON uv.user.id = u.id
-        WHERE u.id = :userId
-        """)
-    Page<MedicineReview> findByUserIdWithDetails(@Param("userId") String userId, Pageable pageable);
+//    // 특정 유저의 모든 리뷰를 유저 프로필 및 개인정보와 함께 조회
+//    @Query("""
+//        SELECT r FROM MedicineReview r
+//        JOIN FETCH r.user u
+//        JOIN UserProfile up ON up.user.id = u.id
+//        JOIN UserPrivacy uv ON uv.user.id = u.id
+//        WHERE u.id = :userId
+//        """)
+//    Page<MedicineReview> findByUserIdWithDetails(@Param("userId") String userId, Pageable pageable);
 
-    // 특정 약물의 모든 리뷰를 유저 프로필 및 개인정보와 함께 조회
-    @Query("SELECT r FROM MedicineReview r WHERE r.medicine.id = :medicineId")
-    @EntityGraph(attributePaths = {
-            "user", "medicine", "coMedications.medicine"
-    })
-    Page<MedicineReview> findByMedicineIdWithDetails(@Param("medicineId") Long medicineId, Pageable pageable);
+//    // 특정 약물의 모든 리뷰를 유저 프로필 및 개인정보와 함께 조회
+//    @Query("SELECT r FROM MedicineReview r WHERE r.medicine.id = :medicineId")
+//    @EntityGraph(attributePaths = {
+//            "user", "medicine", "coMedications.medicine"
+//    })
+//    Page<MedicineReview> findByMedicineIdWithDetails(@Param("medicineId") Long medicineId, Pageable pageable);
 
     // 모든 리뷰를 유저 프로필 및 개인정보와 함께 조회
     @Query("""
@@ -49,4 +49,28 @@ public interface MedicineReviewRepository extends JpaRepository<MedicineReview, 
         JOIN UserPrivacy uv ON uv.user.id = u.id
         """)
     Page<MedicineReview> findAllWithUserDetails(Pageable pageable);
+
+    @EntityGraph(attributePaths = {
+            "user", "user.userProfile", "user.userPrivacy", "medicine", "coMedications.medicine"
+    })
+    @Query("SELECT r FROM MedicineReview r WHERE r.id = :reviewId")
+    Optional<MedicineReview> findByIdWithUserDetails(@Param("reviewId") Long reviewId);
+
+    @EntityGraph(attributePaths = {
+            "user", "user.userProfile", "user.userPrivacy", "medicine", "coMedications.medicine"
+    })
+    @Query("SELECT r FROM MedicineReview r WHERE r.user.id = :userId")
+    Page<MedicineReview> findByUserIdWithDetails(@Param("userId") String userId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {
+            "user", "user.userProfile", "user.userPrivacy", "medicine", "coMedications.medicine"
+    })
+    @Query("SELECT r FROM MedicineReview r WHERE r.medicine.id = :medicineId")
+    Page<MedicineReview> findByMedicineIdWithDetails(@Param("medicineId") Long medicineId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {
+            "user", "user.userProfile", "user.userPrivacy", "medicine", "coMedications.medicine"
+    })
+    @Query("SELECT r FROM MedicineReview r")
+    Page<MedicineReview> findAllWithDetails(Pageable pageable);
 }

--- a/src/main/java/com/project/foradhd/domain/medicine/web/controller/MedicineReviewController.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/web/controller/MedicineReviewController.java
@@ -33,14 +33,14 @@ public class MedicineReviewController {
     public ResponseEntity<MedicineReviewResponse> createReview(@RequestBody MedicineReviewRequest request, @AuthUserId String userId) {
         MedicineReview review = medicineReviewService.createReview(request, userId);
         // 리뷰를 조회할 때마다 실시간으로 유저 정보를 매핑
-        MedicineReviewResponse response = medicineReviewMapper.toResponseDto(review, userService);
+        MedicineReviewResponse response = medicineReviewMapper.toResponseDto(review, userService, userId);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<MedicineReviewResponse> updateReview(@PathVariable Long id, @RequestBody MedicineReviewRequest request, @AuthUserId String userId) {
         MedicineReview review = medicineReviewService.updateReview(id, request, userId);
-        MedicineReviewResponse response = medicineReviewMapper.toResponseDto(review, userService);
+        MedicineReviewResponse response = medicineReviewMapper.toResponseDto(review, userService, userId);
         return ResponseEntity.ok(response);
     }
 
@@ -54,10 +54,11 @@ public class MedicineReviewController {
 
     @GetMapping
     public ResponseEntity<MedicineReviewResponse.PagedMedicineReviewResponse> getReviews(
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthUserId String userId) {
         Page<MedicineReview> reviews = medicineReviewService.findReviews(pageable);
         List<MedicineReviewResponse> reviewDtoList = reviews.stream()
-                .map(review -> medicineReviewMapper.toResponseDto(review, userService))
+                .map(review -> medicineReviewMapper.toResponseDto(review, userService, userId))
                 .toList();
 
         PagingResponse pagingResponse = PagingResponse.from(reviews);
@@ -80,7 +81,7 @@ public class MedicineReviewController {
 
         // 엔티티를 DTO로 변환
         List<MedicineReviewResponse> reviewDtos = reviews.stream()
-                .map(review -> medicineReviewMapper.toResponseDto(review, userService))
+                .map(review -> medicineReviewMapper.toResponseDto(review, userService, userId))
                 .collect(Collectors.toList());
 
         PagingResponse pagingResponse = PagingResponse.from(reviews);
@@ -97,10 +98,10 @@ public class MedicineReviewController {
     public ResponseEntity<MedicineReviewResponse.PagedMedicineReviewResponse> getReviewsByMedicineId(
             @PathVariable Long medicineId,
             @RequestParam(defaultValue = "NEWEST_FIRST") SortOption sortOption,
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable, @AuthUserId String userId) {
         Page<MedicineReview> reviews = medicineReviewService.findReviewsByMedicineId(medicineId, pageable, sortOption);
         List<MedicineReviewResponse> reviewDtos = reviews.stream()
-                .map(review -> medicineReviewMapper.toResponseDto(review, userService))
+                .map(review -> medicineReviewMapper.toResponseDto(review, userService, userId))
                 .collect(Collectors.toList());
 
         PagingResponse pagingResponse = PagingResponse.from(reviews);

--- a/src/main/java/com/project/foradhd/domain/medicine/web/dto/response/MedicineReviewResponse.java
+++ b/src/main/java/com/project/foradhd/domain/medicine/web/dto/response/MedicineReviewResponse.java
@@ -1,5 +1,6 @@
 package com.project.foradhd.domain.medicine.web.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.project.foradhd.domain.user.persistence.enums.Gender;
 import com.project.foradhd.global.paging.web.dto.response.PagingResponse;
@@ -29,6 +30,8 @@ public class MedicineReviewResponse {
     private Gender gender;
     private double averageGrade;
     private String medicineName;
+    @JsonProperty("isAuthor")
+    private boolean isAuthor;
     @JsonSerialize(using = LocalDateTimeToEpochSecondSerializer.class)
     private LocalDateTime createdAt;
     @JsonSerialize(using = LocalDateTimeToEpochSecondSerializer.class)


### PR DESCRIPTION
## 💻 구현 내용 
- 약 리뷰 조회 시 로그인한 유저가 해당 리뷰의 작성자인지 판별하여 isAuthor 필드로 내려주도록 구현하였습니다.
- 로그인한 유저의 식별자인 `userId`를 `@AuthUserId`를 통해 컨트롤러에서 추출하고, 매퍼에서 리뷰 작성자의 ID와 비교하여 `isAuthor` 여부를 판단합니다.

###**MedicineReviewResponse DTO**
- boolean `isAuthor` 필드 추가
- Jackson 직렬화 시 "isAuthor"로 명확히 내려주기 위해 `@JsonProperty("isAuthor")` 어노테이션 사용

###**Mapper 변경 사항**
- `toResponseDto` 메서드에 `@Context String currentUserId` 파라미터 추가
- `@AfterMapping` 내에서 r`eview.getUser().getId().equals(currentUserId)`로 작성자 여부 판단

###**Controller 변경 사항**
- 모든 리뷰 조회 API(`getReviews`, `getReviewsByMedicineId`, `getUserReviews`, `createReview`, `updateReview`)에서 `userId`를 매퍼에 넘기도록 수정

## 🛠️ 개발 오류 사항
`isAuthor`로 정의된 필드가 JSON 응답에서 "`author`"로 내려오는 문제 발생
→ 원인: Lombok이 `isAuthor` 필드에 대해 `isIsAuthor()`라는 getter를 자동 생성하여 Jackson이 필드를 "`author`"로 직렬화함
→ 해결: `@JsonProperty("isAuthor")` 어노테이션을 DTO 필드에 명시하여 명확한 키 이름 지정


## 🗣️ For 리뷰어
- 약 리뷰 조회 시 isAuthor 필드값이 제대로 매핑되고 내려오는지 확인 부탁드립니다.

close #171 