### PR TITLE
feat: prometheus 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	// Prometheus 설정
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,20 @@ spring:
       circuitbreaker:
         enabled: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    tags:
+      application: foradhd-server
+
 jwt:
   expiry:
     access-token: 3600000 #60 * 60 * 1000 (1 hour)


### PR DESCRIPTION


## 💻 구현 내용 
- application.yml: prometheus, health, info endpoint 노출
- application.yml: 메트릭 export 활성화 & application 태그로 서비스명 지정
- build.gradle: Prometheus 연동을 위해 micrometer registry 및 actuator 의존성 추가
- build.gradle: 메트릭 수집 및 노출을 위한 기반 구성

close #177 