### PR TITLE
bugfix: 약 별 리뷰 조회 시 500에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,9 @@ tasks.register('integrationTest', Test) {
 jar {
 	enabled = false
 }
+bootJar {
+	enabled = true
+}
 
 sonarqube {
 	properties {

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
@@ -30,6 +30,9 @@ public class User extends BaseTimeEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserProfile userProfile;
 
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    private UserPrivacy userPrivacy;
+
     @Column(nullable = false, length = 100)
     private String email;
 

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
@@ -30,7 +30,7 @@ public class User extends BaseTimeEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserProfile userProfile;
 
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserPrivacy userPrivacy;
 
     @Column(nullable = false, length = 100)


### PR DESCRIPTION
## 💻 구현 내용 
- 기존에 User 엔티티가 `UserPrivacy`와의 연관 관계를 명시적으로 가지고 있지 않아, EntityGraph나 Fetch Join 시 오류가 발생함
- 이를 해결하기 위해 `User` 엔티티에 `UserPrivacy`와의 1:1 연관 관계를 명시적으로 추가

## 🛠️ 개발 오류 사항
- @EntityGraph 사용 시 "Unable to locate Attribute with the given name [userPrivacy] on this ManagedType" 오류 발생
- 원인: User 엔티티에 userPrivacy 필드가 존재하지 않았기 때문
- 시도한 해결 방법:
    처음엔 Fetch Join 쿼리 방식으로 우회 시도 → 동작은 가능하나 코드 일관성이 떨어짐
- 최종 해결:
    User 엔티티에 userPrivacy 필드 추가하고 연관 관계 매핑함으로써 EntityGraph 정상 작동 확인

## 🗣️ For 리뷰어
- User ↔ UserPrivacy의 연관 관계 매핑 방식이 적절한지
- 기존 EntityGraph를 사용하는 쿼리에서 정상적으로 작동하는지 (N+1 문제 해결 여부 포함)
- cascade, fetch 설정이 서비스 흐름에 적절한지
- 연관된 Entity 변경 사항이므로 추후 DB schema에도 영향이 없는지 한 번 확인 부탁드립니다.

close #181 