### PR TITLE
bugfix: 새 댓글에 대한 sse 알림 에러 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,9 @@ tasks.register('integrationTest', Test) {
 jar {
 	enabled = false
 }
+bootJar {
+	enabled = true
+}
 
 sonarqube {
 	properties {

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/CommentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.project.foradhd.domain.board.business.service.Impl;
 
 import com.project.foradhd.domain.board.business.service.CommentService;
+import com.project.foradhd.domain.board.business.service.NotificationService;
 import com.project.foradhd.domain.board.persistence.entity.Comment;
 import com.project.foradhd.domain.board.persistence.entity.CommentLikeFilter;
 import com.project.foradhd.domain.board.persistence.entity.Post;
@@ -31,6 +32,7 @@ import static org.springframework.data.jpa.repository.query.QueryUtils.applySort
 public class CommentServiceImpl implements CommentService {
 
     private final UserService userService;
+    private final NotificationService notificationService;
     private final CommentRepository commentRepository;
     private final CommentLikeFilterRepository commentLikeFilterRepository;
     private final PostRepository postRepository;
@@ -82,7 +84,17 @@ public class CommentServiceImpl implements CommentService {
                     .profileImage(userProfile.getProfileImage());
         }
 
-        return commentRepository.save(commentBuilder.build());
+        Comment savedComment = commentRepository.save(commentBuilder.build());
+
+        // 🔔 알림 전송 (댓글 작성자와 게시글 작성자가 다를 경우에만)
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_POST));
+        if (!post.getUser().getId().equals(userId)) {
+            String message = "내 게시글에 새로운 댓글이 달렸어요: " + savedComment.getContent();
+            notificationService.createNotification(post.getUser().getId(), message);
+        }
+
+        return savedComment;
     }
 
 

--- a/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/Impl/PostServiceImpl.java
@@ -147,12 +147,20 @@ public class PostServiceImpl implements PostService {
         return topPosts;
     }
 
+    @Override
     @Transactional
-    private void notifyUsersAboutTopPosts(List<Post> topPosts) {
+    public void notifyUsersAboutTopPosts(List<Post> topPosts) {
         for (Post post : topPosts) {
+            if (Boolean.TRUE.equals(post.getNotifiedAsTop())) {
+                continue;
+            }
             String message = "내 글이 TOP 10 게시물로 선정됐어요!";
             notificationService.createNotification(post.getUser().getId(), message);
             sseEmitters.sendNotification(post.getUser().getId(), message);
+            Post updatedPost = post.toBuilder()
+                    .notifiedAsTop(true)
+                    .build();
+            postRepository.save(updatedPost);
         }
     }
 

--- a/src/main/java/com/project/foradhd/domain/board/business/service/PostService.java
+++ b/src/main/java/com/project/foradhd/domain/board/business/service/PostService.java
@@ -5,6 +5,7 @@ import com.project.foradhd.domain.board.persistence.enums.Category;
 import com.project.foradhd.domain.board.persistence.enums.SortOption;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -38,6 +39,10 @@ public interface PostService {
 
     // 메인홈 - 카테고리별 실시간 랭킹
     Page<Post> getTopPostsByCategory(Category category, Pageable pageable);
+
+    @Transactional
+    void notifyUsersAboutTopPosts(List<Post> topPosts);
+
     // SSE 알림 관련 설정
     void addComment(Long postId, String commentContent, String userId);
     List<String> getRecentSearchTerms(String userId);

--- a/src/main/java/com/project/foradhd/domain/board/persistence/entity/Post.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/entity/Post.java
@@ -74,8 +74,9 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer viewCount = 0;
 
+    @Builder.Default
     @Column(nullable = false)
-    private boolean notifiedAsTop = false;
+    private Boolean notifiedAsTop = false;
 
     public void incrementLikeCount() {
         this.likeCount++;

--- a/src/main/java/com/project/foradhd/domain/board/persistence/entity/Post.java
+++ b/src/main/java/com/project/foradhd/domain/board/persistence/entity/Post.java
@@ -74,6 +74,9 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer viewCount = 0;
 
+    @Column(nullable = false)
+    private boolean notifiedAsTop = false;
+
     public void incrementLikeCount() {
         this.likeCount++;
     }

--- a/src/main/java/com/project/foradhd/domain/board/web/controller/NotificationController.java
+++ b/src/main/java/com/project/foradhd/domain/board/web/controller/NotificationController.java
@@ -11,6 +11,7 @@ import com.project.foradhd.global.AuthUserId;
 import com.project.foradhd.global.util.SseEmitters;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -27,7 +28,7 @@ public class NotificationController {
     private final PostService postService;
     private final NotificationRepository notificationRepository;
 
-    @GetMapping("/sse")
+    @GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter streamSseMvc(@AuthUserId String userId) {
         // 타임아웃을 1시간(3600000ms)으로 설정
         SseEmitter emitter = new SseEmitter(3600000L);

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
@@ -30,6 +30,9 @@ public class User extends BaseTimeEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserProfile userProfile;
 
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    private UserPrivacy userPrivacy;
+
     @Column(nullable = false, length = 100)
     private String email;
 

--- a/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/project/foradhd/domain/user/persistence/entity/User.java
@@ -30,7 +30,7 @@ public class User extends BaseTimeEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserProfile userProfile;
 
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserPrivacy userPrivacy;
 
     @Column(nullable = false, length = 100)


### PR DESCRIPTION
## 💻 구현 내용 
**- TOP10 게시글 알림 중복 방지 로직 추가**
- 기존에는 게시글이 Top10에 다시 포함될 경우 매번 알림이 전송되어 불필요한 중복 알림과 DB 부하가 발생.
- Post 엔티티에 notifiedAsTop Boolean 필드를 추가하고, 알림 발송 여부를 체크.
- 알림을 보내기 전에 해당 필드가 false인 경우에만 전송, 이후 true로 업데이트.
- 빌더 패턴을 사용하는 구조이므로, 기존 Post 객체를 toBuilder()로 복사하여 notifiedAsTop(true) 설정 후 저장.

**- 주요 케이스 설명**
최초 Top10 선정 시 → 알림 전송 + notifiedAsTop = true
이후 다시 Top10에 올라가도 → 알림 전송되지 않음

## 🛠️ 개발 오류 사항


## 🗣️ For 리뷰어
- notifyUsersAboutTopPosts() 내부 로직 변경 사항에 주목해주세요.
- 추후 이와 유사하게 알림 중복 방지 로직을 댓글 알림에도 확장할지 검토 예정입니다.
- Post 객체에 새로운 필드를 도입한 만큼, 기존 DB에서의 기본값이 어떻게 들어가는지도 한 번 확인해주시면 좋겠습니다.

close #183 