### PR TITLE
bugfix: 의존성 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ dependencies {
 	// Prometheus 설정
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'io.netty:netty-all:4.1.108.Final'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 🛠️ 개발 오류 사항

### ❗ Netty 관련 클래스 충돌 오류 (`NoClassDefFoundError: io/netty/channel/AbstractChannelHandlerContext$11`)

- 문제 상황: 앱 종료 시 Redis 연결 해제 로직에서 Netty 클래스 관련 오류 발생
- 원인 분석:
  - `spring-boot-starter-data-redis`에서 사용하는 Netty 버전과 다른 의존성(Netty를 transitively 사용하는 라이브러리) 간의 버전 충돌
  - 정확한 오류 메시지: `NoClassDefFoundError: io/netty/channel/AbstractChannelHandlerContext$11`

- 해결 방법:
  - Netty 전역 버전을 명시적으로 고정: `io.netty:netty-all:4.1.108.Final` 추가
  - Gradle의 의존성 트리 분석 도구(`./gradlew dependencies`)를 통해 버전 충돌 여부 확인
  - 이후 동일 오류 발생하지 않음 (서버 종료 시에도 정상 로그 출력됨)

## 🗣️ For 리뷰어

- `build.gradle`에 Prometheus 관련 의존성 추가가 많지 않지만, Netty 관련 하위 의존성과 충돌이 있을 수 있어 유의해 주세요.
- Redis, Feign, AWS 등 다양한 라이브러리들이 Netty를 사용하는 만큼, 추후 다른 모듈에서도 Netty 버전 충돌 이슈가 재현될 수 있습니다.
- 필요 시 `dependencyManagement`를 활용해 전역 버전을 통제하는 방법도 고려할 수 있습니다.

close #187 